### PR TITLE
Dev/redmine api refactor

### DIFF
--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -130,23 +130,23 @@ func ListIssues(redmineConf cfg.RedmineConfig) (IssuesRes, error) {
 
 func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry) error {
 	var ir timeEntryRequest
+
 	ir.TimeEntry = timeEntry
 	s, err := json.Marshal(ir)
 	if err != nil {
 		return err
 	}
-	method := "POST"
 
-	client := &http.Client{}
-	req, err := http.NewRequest(method, redmineConf.Host+":"+redmineConf.Port+"/time_entries.json", strings.NewReader(string(s)))
+	req, err := prepareRequest(redmineConf, "POST", "/time_entries.json")
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 	req.Header.Add("X-Redmine-API-Key", redmineConf.ApiKey)
-	req.Header.Set("Content-Type", "application/json")
 	// Here we impersonate as a user to report his/her time
 	req.Header.Set("X-Redmine-Switch-User", "jon")
 
+	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
 		log.Errorf("Failed to create time entry: %s", err)
@@ -157,8 +157,8 @@ func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry) error {
 	if res.StatusCode != 201 {
 		log.Errorf("Failed to create time entry: %s", res.Status)
 		return errors.New(res.Status)
-	} else {
-		log.Infof("Created time entry: %s", s)
 	}
+	log.Infof("Created time entry: %s", s)
+
 	return nil
 }

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -84,7 +84,7 @@ func Login(authHeader string, redmineConf cfg.RedmineConfig) bool {
 	}
 	req.Header.Add("Authorization", authHeader)
 
-	var r
+	var r IssuesRes
 
 	client := &http.Client{}
 	res, err := client.Do(req)
@@ -102,35 +102,30 @@ func Login(authHeader string, redmineConf cfg.RedmineConfig) bool {
 
 func ListIssues(redmineConf cfg.RedmineConfig) (IssuesRes, error) {
 
-	url := redmineConf.Host + ":" + redmineConf.Port + "/issues.json"
-	method := "GET"
+	req err := prepareRequest(redmineConf, "GET", "/issues.json")
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	req.Header.Add("X-Redmine-API-Key", redmineConf.ApiKey)
 
 	var r IssuesRes
 
 	client := &http.Client{}
-	req, err := http.NewRequest(method, url, nil)
-
-	if err != nil {
-		fmt.Println(err)
-		return r, err
-	}
-	req.Header.Add("X-Redmine-API-Key", redmineConf.ApiKey)
-	req.Header.Add("Content-Type", "application/json")
-
 	res, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
 		return r, err
 	}
 	defer res.Body.Close()
-	decoder := json.NewDecoder(res.Body)
 
+	decoder := json.NewDecoder(res.Body)
 	err = decoder.Decode(&r)
 	if err != nil {
 		log.Error("Failed decoding response: %s", err)
 	}
-	return r, err
 
+	return r, err
 }
 
 func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry) error {

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	cfg "urdr-api/internal/config"
 
 	log "github.com/sirupsen/logrus"

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -100,16 +100,15 @@ func Login(authHeader string, redmineConf cfg.RedmineConfig) bool {
 	return r.TotalCount != 0
 }
 
-func ListIssues(redmineConf cfg.RedmineConfig) (IssuesRes, error) {
-
-	req err := prepareRequest(redmineConf, "GET", "/issues.json")
+func ListIssues(redmineConf cfg.RedmineConfig) (*IssuesRes, error) {
+	req, err := prepareRequest(redmineConf, "GET", "/issues.json")
 	if err != nil {
 		fmt.Println(err)
-		return false
+		return nil, err
 	}
 	req.Header.Add("X-Redmine-API-Key", redmineConf.ApiKey)
 
-	var r IssuesRes
+	r := &IssuesRes{}
 
 	client := &http.Client{}
 	res, err := client.Do(req)


### PR DESCRIPTION
This PR adds a `doRequest()` function that assembles a HTTP request given a Redmine configuration, an access method, a Redmine endpoint, and a set of headers. The function then performs the request and returns the response object.

The other functions in the Redmine API have been refactored to use `doRequest()`.

There are also some very minor rearrangements of statements to make the functions follow the same approximate steps, and there was one instance of removing an explicit test (in `Login()`).

Apart from making the code ever so slightly shorter, it also moves all instances of talking to Redmine into the new `doRequest()` function.

Tested with `curl`.