### PR TITLE
Switch to non-slim linter to fix `cgo` issues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: develop


### PR DESCRIPTION
Fix linter by switching from the "slim" to the full linter.

See https://github.com/github/super-linter/issues/2153#issuecomment-983616741