### PR TITLE
Dev/database location conf

### DIFF
--- a/backend/.env.default
+++ b/backend/.env.default
@@ -3,3 +3,4 @@ APP_PORT=8080
 REDMINE_HOST="http://host.docker.internal" #If this is not workig please try "http://172.17.0.1"
 REDMINE_PORT=3000
 REDMINE_ADMIN_TOKEN=""
+URDR_DB_PATH="./database.db"

--- a/backend/.env.default
+++ b/backend/.env.default
@@ -1,6 +1,6 @@
 APP_HOST=0.0.0.0
 APP_PORT=8080
+REDMINE_ADMIN_TOKEN=""
 REDMINE_HOST="http://host.docker.internal" #If this is not workig please try "http://172.17.0.1"
 REDMINE_PORT=3000
-REDMINE_ADMIN_TOKEN=""
 URDR_DB_PATH="./database.db"

--- a/backend/.env.default
+++ b/backend/.env.default
@@ -1,6 +1,6 @@
 APP_HOST=0.0.0.0
 APP_PORT=8080
 REDMINE_ADMIN_TOKEN=""
-REDMINE_HOST="http://host.docker.internal" #If this is not workig please try "http://172.17.0.1"
+REDMINE_HOST="http://host.docker.internal"
 REDMINE_PORT=3000
 URDR_DB_PATH="./database.db"

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -10,9 +10,13 @@ import (
 
 // init is run before main, it loads the configuration variables
 func init() {
-	c := &config.Config
-	config.LoadConfig(c)
 	logging.LoggingSetup("debug")
+
+	c := &config.Config
+	err := config.LoadConfig(c)
+	if err != nil {
+		log.Fatalf("config.LoadConfig() failed: %v", err)
+	}
 }
 
 func main() {

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -12,8 +12,7 @@ import (
 func init() {
 	logging.LoggingSetup("debug")
 
-	c := &config.Config
-	err := config.LoadConfig(c)
+	err := config.LoadConfig()
 	if err != nil {
 		log.Fatalf("config.LoadConfig() failed: %v", err)
 	}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	logging.LoggingSetup("debug")
 
-	err := config.LoadConfig()
+	err := config.Setup()
 	if err != nil {
 		log.Fatalf("config.LoadConfig() failed: %v", err)
 	}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -12,7 +12,7 @@ import (
 // init is run before main.  It loads the configuration variables and
 // connects to the database.
 func init() {
-	logging.LoggingSetup("debug")
+	logging.Setup("debug")
 
 	err := config.Setup()
 	if err != nil {

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -4,17 +4,24 @@ import (
 	"urdr-api/api"
 	"urdr-api/internal/config"
 	"urdr-api/internal/logging"
+	"urdr-api/internal/database"
 
 	log "github.com/sirupsen/logrus"
 )
 
-// init is run before main, it loads the configuration variables
+// init is run before main.  It loads the configuration variables and
+// connects to the database.
 func init() {
 	logging.LoggingSetup("debug")
 
 	err := config.LoadConfig()
 	if err != nil {
 		log.Fatalf("config.LoadConfig() failed: %v", err)
+	}
+
+	err = db.Setup()
+	if err != nil {
+		log.Fatalf("db.Setup() failed: %v", err)
 	}
 }
 
@@ -26,5 +33,4 @@ func main() {
 
 	// Start server
 	log.Fatal(app.Listen(config.Config.App.Host + ":" + config.Config.App.Port))
-
 }

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"urdr-api/api"
 	"urdr-api/internal/config"
 	"urdr-api/internal/logging"
-	"urdr-api/internal/database"
+	db "urdr-api/internal/database"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -41,7 +41,7 @@ func getEnv(key string, def string) string {
 }
 
 // LoadConfig populates ConfigMap with data
-func LoadConfig(c *ConfigMap) error {
+func LoadConfig() error {
 	// Load settings from .env
 	err := godotenv.Load(getEnv("DOT_ENV_FILE", ".env"))
 	if err != nil {
@@ -50,14 +50,14 @@ func LoadConfig(c *ConfigMap) error {
 
 	// Populate config structs, place defaults if empty in .env
 
-	c.App.Host = getEnv("APP_HOST", "127.0.0.1")
-	c.App.Port = getEnv("APP_PORT", "8080")
+	Config.App.Host = getEnv("APP_HOST", "127.0.0.1")
+	Config.App.Port = getEnv("APP_PORT", "8080")
 
-	c.Redmine.Host = getEnv("REDMINE_HOST", "redmine")
-	c.Redmine.Port = getEnv("REDMINE_PORT", "3000")
-	c.Redmine.ApiKey = getEnv("REDMINE_ADMIN_TOKEN", "")
+	Config.Redmine.Host = getEnv("REDMINE_HOST", "redmine")
+	Config.Redmine.Port = getEnv("REDMINE_PORT", "3000")
+	Config.Redmine.ApiKey = getEnv("REDMINE_ADMIN_TOKEN", "")
 
-	c.Database.Path = getEnv("URDR_DB_PATH", "./database.db")
+	Config.Database.Path = getEnv("URDR_DB_PATH", "./database.db")
 
 	return nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -40,8 +40,8 @@ func getEnv(key string, def string) string {
 	return def
 }
 
-// LoadConfig populates ConfigMap with data
-func LoadConfig() error {
+// Setup populates ConfigMap with data
+func Setup() error {
 	// Load settings from .env
 	err := godotenv.Load(getEnv("DOT_ENV_FILE", ".env"))
 	if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -12,8 +12,9 @@ var Config ConfigMap
 
 // ConfigMap stores all different configs
 type ConfigMap struct {
-	App     AppConfig
-	Redmine RedmineConfig
+	App      AppConfig
+	Redmine  RedmineConfig
+	Database DatabaseConfig
 }
 
 type AppConfig struct {
@@ -25,6 +26,10 @@ type RedmineConfig struct {
 	Host   string
 	Port   string
 	ApiKey string
+}
+
+type DatabaseConfig struct {
+	Path string
 }
 
 // getEnv returns given os.Getenv value, or a default value if os.Getenv is empty
@@ -51,6 +56,8 @@ func LoadConfig(c *ConfigMap) error {
 	c.Redmine.Host = getEnv("REDMINE_HOST", "redmine")
 	c.Redmine.Port = getEnv("REDMINE_PORT", "3000")
 	c.Redmine.ApiKey = getEnv("REDMINE_ADMIN_TOKEN", "")
+
+	c.Database.Path = getEnv("URDR_DB_PATH", "./database.db")
 
 	return nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
-	log "github.com/sirupsen/logrus"
 )
 
 // Config is a global configuration value store
@@ -27,8 +27,8 @@ type RedmineConfig struct {
 	ApiKey string
 }
 
-// GetEnv returns given os.Getenv value, or a default value if os.Getenv is empty
-func GetEnv(key string, def string) string {
+// getEnv returns given os.Getenv value, or a default value if os.Getenv is empty
+func getEnv(key string, def string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
@@ -36,16 +36,21 @@ func GetEnv(key string, def string) string {
 }
 
 // LoadConfig populates ConfigMap with data
-func LoadConfig(c *ConfigMap) {
+func LoadConfig(c *ConfigMap) error {
 	// Load settings from .env
-	err := godotenv.Load(GetEnv("DOT_ENV_FILE", ".env"))
+	err := godotenv.Load(getEnv("DOT_ENV_FILE", ".env"))
 	if err != nil {
-		log.Errorf("failed to load environment variables from .env, %s", err)
+		return fmt.Errorf("godotenv.Load() failed: %w", err)
 	}
+
 	// Populate config structs, place defaults if empty in .env
-	c.App.Host = GetEnv("APP_HOST", "127.0.0.1")
-	c.App.Port = GetEnv("APP_PORT", "8080")
-	c.Redmine.Host = GetEnv("REDMINE_HOST", "redmine")
-	c.Redmine.Port = GetEnv("REDMINE_PORT", "3000")
-	c.Redmine.ApiKey = GetEnv("REDMINE_ADMIN_TOKEN", "")
+
+	c.App.Host = getEnv("APP_HOST", "127.0.0.1")
+	c.App.Port = getEnv("APP_PORT", "8080")
+
+	c.Redmine.Host = getEnv("REDMINE_HOST", "redmine")
+	c.Redmine.Port = getEnv("REDMINE_PORT", "3000")
+	c.Redmine.ApiKey = getEnv("REDMINE_ADMIN_TOKEN", "")
+
+	return nil
 }

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1,10 +1,12 @@
 package database
 
 import (
-	"database/sql"
-	_ "github.com/mattn/go-sqlite3"
+	"urdr-api/internal/config"
 
-	log "github.com/sirupsen/logrus"
+	"fmt"
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 // db is a package-global variable that keeps track of the database
@@ -12,15 +14,17 @@ import (
 // function.
 var db *sql.DB
 
-// init connects to the database, initializing the package-global
+// Setup connects to the database, initializing the package-global
 // variable db.
-func init() {
+func Setup() error {
 	var err error
 
 	db, err = sql.Open("sqlite3",
-		"./database.db?_auto_vacuum=FULL&_foreign_keys=true")
+		config.Config.Database.Path+
+			"?_auto_vacuum=FULL&_foreign_keys=true")
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("sql.Open() failed: %w", err)
 	}
-}
 
+	return nil
+}

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -10,6 +10,11 @@ import (
 // the value stored for a setting, given the setting's name.  It returns
 // an error for illegal settings.
 func getSetting(settingName string) (int, string, error) {
+	err := db.Ping()
+	if err != nil {
+		return 0, "", fmt.Errorf("db.Ping() failed: %w", err)
+	}
+
 	sqlStmt := `
 		SELECT	setting_id, value
 		FROM	setting

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -3,7 +3,6 @@ package database
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 // getSetting is an internal function that returns the setting_id and

--- a/backend/internal/logging/logging.go
+++ b/backend/internal/logging/logging.go
@@ -28,8 +28,8 @@ func determineLogLevel(level string) log.Level {
 	}
 }
 
-// LoggingSetup configures logging format and rules
-func LoggingSetup(logLevel string) {
+// Setup configures logging format and rules
+func Setup(logLevel string) {
 	// Log formatting
 	log.SetFormatter(&log.TextFormatter{
 		DisableColors: true,


### PR DESCRIPTION
This PR is related to issue #84 depends on PR #83
This PR closes #85 

* It changes the configuration slightly so that the `LoadConfig()` function is called without arguments. The configuration is global and accessible through `config.Config`.

* It replaces the `init()` function in `database` with `Setup()`.  The `init()` function did not have access to to the loaded configuration, even though `main` called `LoadConfig()` in _its_ `init()` function.  Therefore, call `LoadConfig()` in `main.init()`, and then `database.Setup()`.

* It adds a structure to the configuration that holds the pathname of the database file.
* It makes `getEnv()` internal (was `GetEnv()`).


Example program (the `main` function is the same as in the previous example code):

```go
package main

import (
        conf "urdr-api/internal/config"
        db "urdr-api/internal/database"
        "log"
)

func init() {
        err := conf.Setup()
        if err != nil {
                log.Fatalf("conf.Setup() failed: %v", err)
        }

        err = db.Setup()
        if err != nil {
                log.Fatalf("db.Setup() failed: %v", err)
        }
}

func main() {
        val, err := db.GetUserSetting(1, "tab")
        if err != nil {
                log.Fatalf("db.GetUserSetting() failed: %v", err)
        }
        log.Print(val)

        err = db.SetUserSetting(1, "tab", "vertical")
        if err != nil {
                log.Fatalf("db.SetUserSetting() failed: %v", err)
        }

        val, err = db.GetUserSetting(1, "tab")
        if err != nil {
                log.Fatalf("db.GetUserSetting() failed: %v", err)
        }
        log.Print(val)

        err = db.DeleteUserSetting(1, "tab")
        if err != nil {
                log.Fatalf("db.DeleteUserSetting() failed: %v", err)
        }

        val, err = db.GetUserSetting(1, "tab")
        if err != nil {
                log.Fatalf("db.GetUserSetting() failed: %v", err)
        }
        log.Print(val)
}
```