### PR TITLE
Utilise user tokens for consuming the redmine api

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ psql -U redmine
 redmine=> update users set admin='t' where login='MYUSER';
 ```
 
-Now please create the env file `.env` using `.env.default` as a template. If you are on Linux you need to set the variable `REDMINE_HOST="http://172.17.0.1"`. Then, fetch the API key of your Redmine user by navigating to your page, and update `.urdr.env` by setting the variable `REDMINE_ADMIN_TOKEN`.
+Now please create the env file `.env` using `.env.default` as a template. If you are on Linux you need to set the variable `REDMINE_HOST="http://172.17.0.1"`.
 
 Finally, you can start Urdr by using:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ docker-compose build
 docker-compose up
 ```
 
+## Frontend dev server
+
+In order to install/update packages in the node server you should:
+
+- Make the neccessary updates in the package.json
+- Execute the following commands:
+
+```command
+docker-compose down node-urdr --volumes
+docker-compose build node-urdr
+docker-compose up node-urdr
+```
+
 ## Frontend
 
 [Node.js server](http://localhost:4242)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker-compose up
 
 ## Frontend dev server
 
-In order to install/update packages in the node server you should:
+In order to install/update packages in the node-urdr server you should:
 
 - Make the neccessary updates in the package.json
 - Execute the following commands:

--- a/backend/.env.default
+++ b/backend/.env.default
@@ -1,6 +1,5 @@
 APP_HOST=0.0.0.0
 APP_PORT=8080
-REDMINE_ADMIN_TOKEN=""
 REDMINE_HOST="http://host.docker.internal"
 REDMINE_PORT=3000
 URDR_DB_PATH="./database.db"

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -44,13 +44,6 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 		KeyGenerator:   utils.UUID,
 	})
 
-	app.Get("/", func(c *fiber.Ctx) error {
-		if !isLoggedIn(c, store) {
-			return c.SendStatus(401)
-		}
-		return c.SendString("Hello, World!")
-	})
-
 	app.Post("/api/login", func(c *fiber.Ctx) error {
 		sess, err := store.Get(c)
 		if err != nil {

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -51,19 +51,18 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 			return c.SendStatus(500)
 		}
 		authHeader := c.Get("Authorization")
-		res, apiKey := redmine.Login(redmineConf, authHeader)
-		if res {
-			sess.Set("api_key", apiKey)
-			err = sess.Save()
-			if err != nil {
-				log.Errorf("Failed to save session: %s", err)
-			}
-			log.Info("Logged in user")
-			return c.SendStatus(200)
-		} else {
+		apiKey, err := redmine.Login(redmineConf, authHeader)
+		if err != nil {
 			log.Info("Log in failed")
 			return c.SendStatus(401)
 		}
+		sess.Set("api_key", apiKey)
+		err = sess.Save()
+		if err != nil {
+			log.Errorf("Failed to save session: %s", err)
+		}
+		log.Info("Logged in user")
+		return c.SendStatus(200)
 	})
 
 	app.Get("/api/logout", func(c *fiber.Ctx) error {

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -51,7 +51,7 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 			return c.SendStatus(500)
 		}
 		authHeader := c.Get("Authorization")
-		res, apiKey := redmine.Login(authHeader, redmineConf)
+		res, apiKey := redmine.Login(redmineConf, authHeader)
 		if res {
 			sess.Set("is_logged_in", true)
 			sess.Set("api_key", apiKey)

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -53,7 +53,6 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 		authHeader := c.Get("Authorization")
 		res, apiKey := redmine.Login(redmineConf, authHeader)
 		if res {
-			sess.Set("is_logged_in", true)
 			sess.Set("api_key", apiKey)
 			err = sess.Save()
 			if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,9 +23,8 @@ type AppConfig struct {
 }
 
 type RedmineConfig struct {
-	Host   string
-	Port   string
-	ApiKey string
+	Host string
+	Port string
 }
 
 type DatabaseConfig struct {
@@ -55,7 +54,6 @@ func Setup() error {
 
 	Config.Redmine.Host = getEnv("REDMINE_HOST", "redmine")
 	Config.Redmine.Port = getEnv("REDMINE_PORT", "3000")
-	Config.Redmine.ApiKey = getEnv("REDMINE_ADMIN_TOKEN", "")
 
 	Config.Database.Path = getEnv("URDR_DB_PATH", "./database.db")
 

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -96,13 +96,12 @@ func doRequest(
 	return res, nil
 }
 
-func Login(redmineConf cfg.RedmineConfig, authHeader string) (bool, string) {
+func Login(redmineConf cfg.RedmineConfig, authHeader string) (string, error) {
 	res, err :=
 		doRequest(redmineConf, "GET", "/my/account.json",
 			map[string]string{"Authorization": authHeader}, "")
 	if err != nil {
-		log.Error(err)
-		return false, ""
+		return "", err
 	}
 	defer res.Body.Close()
 
@@ -112,11 +111,10 @@ func Login(redmineConf cfg.RedmineConfig, authHeader string) (bool, string) {
 
 	err = decoder.Decode(&a)
 	if err != nil {
-		log.Error(err)
-		return false, ""
+		return "", err
 	}
 	log.Debugf("User %s: credentials are valid", a.User.Login)
-	return res.StatusCode == 200, a.User.ApiKey
+	return a.User.ApiKey, nil
 }
 
 func ListIssues(redmineConf cfg.RedmineConfig, apiKey string) (*IssuesRes, error) {

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -152,8 +152,7 @@ func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry, apiKey 
 
 	res, err :=
 		doRequest(redmineConf, "POST", "/time_entries.json",
-			map[string]string{"X-Redmine-API-Key": apiKey,
-				"X-Redmine-Switch-User": "jon"}, string(s))
+			map[string]string{"X-Redmine-API-Key": apiKey}, string(s))
 	if err != nil {
 		log.Errorf("Failed to create time entry: %s", err)
 		return err

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -96,7 +96,7 @@ func doRequest(
 	return res, nil
 }
 
-func Login(authHeader string, redmineConf cfg.RedmineConfig) (bool, string) {
+func Login(redmineConf cfg.RedmineConfig, authHeader string) (bool, string) {
 	res, err :=
 		doRequest(redmineConf, "GET", "/my/account.json",
 			map[string]string{"Authorization": authHeader}, "")

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -119,10 +119,10 @@ func Login(authHeader string, redmineConf cfg.RedmineConfig) (bool, string) {
 	return res.StatusCode == 200, a.User.ApiKey
 }
 
-func ListIssues(redmineConf cfg.RedmineConfig) (*IssuesRes, error) {
+func ListIssues(redmineConf cfg.RedmineConfig, apiKey string) (*IssuesRes, error) {
 	res, err :=
 		doRequest(redmineConf, "GET", "/issues.json",
-			map[string]string{"X-Redmine-API-Key": redmineConf.ApiKey}, "")
+			map[string]string{"X-Redmine-API-Key": apiKey}, "")
 
 	r := &IssuesRes{}
 
@@ -141,7 +141,7 @@ func ListIssues(redmineConf cfg.RedmineConfig) (*IssuesRes, error) {
 	return r, err
 }
 
-func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry) error {
+func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry, apiKey string) error {
 	var ir timeEntryRequest
 
 	ir.TimeEntry = timeEntry
@@ -152,7 +152,7 @@ func CreateTimeEntry(redmineConf cfg.RedmineConfig, timeEntry TimeEntry) error {
 
 	res, err :=
 		doRequest(redmineConf, "POST", "/time_entries.json",
-			map[string]string{"X-Redmine-API-Key": redmineConf.ApiKey,
+			map[string]string{"X-Redmine-API-Key": apiKey,
 				"X-Redmine-Switch-User": "jon"}, string(s))
 	if err != nil {
 		log.Errorf("Failed to create time entry: %s", err)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,23 +5,12 @@
   "author": "NBIS",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@babel/core": "^7.13.16",
-    "@babel/preset-env": "^7.13.15",
-    "@babel/preset-react": "^7.13.13",
-    "@babel/preset-typescript": "^7.13.0",
-    "@snowpack/app-scripts-react": "^2.0.1",
-    "@testing-library/react": "^12.1.3",
-    "@types/react": "^17.0.4",
-    "@types/react-dom": "^17.0.3",
-    "@types/react-router-dom": "^5.1.7",
-    "@types/react-select": "^5.0.1",
-    "@types/snowpack-env": "^2.3.3",
-    "@types/styled-components": "^5.1.9",
-    "base-64": "^1.0.0",
-    "esbuild": "^0.11.15",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.2",
+    "esbuild": "^0.14.23",
     "snowpack": "^3.8.8",
-    "typescript": "^4.2.4",
-    "css-loader": "^6.2.0"
+    "@snowpack/app-scripts-react": "^2.0.1",
+    "react-router-dom": "^6.2.1"
   },
   "scripts": {
     "start": "npx snowpack dev",
@@ -29,20 +18,8 @@
     "build:snowpack": "npx snowpack build"
   },
   "dependencies": {
-    "@date-io/core": "^1.3.13",
-    "@date-io/date-fns": "^1.3.13",
-    "@material-ui/core": "^4.11.3",
-    "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "^4.0.0-alpha.57",
-    "@material-ui/pickers": "^3.3.10",
-    "@snowpack/plugin-react-refresh": "^2.5.0",
-    "date-fns": "2.28.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-icons": "^4.2.0",
-    "react-is": "^17.0.2",
-    "react-number-format": "^4.6.3",
-    "react-router-dom": "^6.2.1",
-    "styled-components": "^5.2.3"
+    "react-router-dom": "^6.2.1"
   }
 }

--- a/frontend/src/pages/Reporter.tsx
+++ b/frontend/src/pages/Reporter.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from "react";
-import DateFnsUtils from "@date-io/date-fns";
-import { TextField, Button } from "@material-ui/core";
 
 export interface TimeEntry {
   issue_id: number;
@@ -90,36 +88,7 @@ export function Reporter() {
 
   return (
     <>
-      <TextField
-        id="hours"
-        autoFocus
-        placeholder="8"
-        margin="dense"
-        label="hours"
-        value={hours}
-        onChange={(e) => set_hours(e.target.value)}
-      ></TextField>
-      <IssuesList />
-      <TextField
-        id="activity"
-        placeholder="18"
-        margin="dense"
-        label="activity"
-        value={activity}
-        onChange={(e) => set_activity(e.target.value)}
-      ></TextField>
-      <Button
-        style={reportButtonStyle}
-        label="Submit"
-        onClick={() => reportTime()}
-        key={"report"}
-        name={"report"}
-        visible="true"
-        type={"submit"}
-      >
-        {" "}
-        Report
-      </Button>
+      <button onClick={reportTime()}>Report time</button>{" "}
     </>
   );
 }

--- a/frontend/src/pages/Reporter.tsx
+++ b/frontend/src/pages/Reporter.tsx
@@ -79,16 +79,5 @@ export function Reporter() {
     });
   }
 
-  const reportButtonStyle = {
-    width: "50",
-    border: "3px solid darkblue",
-    margin: "0px 50px",
-    padding: "10px",
-  };
-
-  return (
-    <>
-      <button onClick={reportTime()}>Report time</button>{" "}
-    </>
-  );
+  return <input type="button" onClick={reportTime} value="Report time" />;
 }

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,4 +10,4 @@ USER node
 RUN npm install && npm run build
 VOLUME /home/node/app/node_modules
 
-CMD ["npx", "snowpack dev"]
+CMD ["npx", "snowpack", "dev"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,4 +10,4 @@ USER node
 RUN npm install && npm run build
 VOLUME /home/node/app/node_modules
 
-CMD npm --version && npx snowpack dev
+CMD ["npx", "snowpack dev"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts
-RUN npm install --global npm@7
+RUN npm install --global npm@8
 
 RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 COPY /frontend/ /home/node/app/


### PR DESCRIPTION
- Remove redmine admin token var
- Remove description about admin tokens
- Use session api tokens
- Rework Login to use redmine account endpoint
- Use user api token for issues and time entries
- Do not impersonate user
