### PR TITLE
Alternative solution for spent time retrieval

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -83,22 +83,8 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 		return c.SendStatus(200)
 	})
 
-	app.Get("/api/time_entries", func(c *fiber.Ctx) error {
-		apiKey, err := getSessionApiKey(c, store)
-		if err != nil {
-			log.Errorf("Failed to get session api key: %v", err)
-			return c.SendStatus(401)
-		}
-		timeEntries, err := redmine.GetTimeEntries(redmineConf, apiKey, c.Query("start", defaultDate), c.Query("end", defaultDate))
-		if err != nil {
-			log.Errorf("Failed to get recent time entries: %v", err)
-			c.Response().SetBodyString(err.Error())
-			return c.SendStatus(500)
-		}
-		return c.JSON(timeEntries)
-	})
+	app.Get("/api/spent_time", func(c *fiber.Ctx) error {
 
-	app.Get("/api/issues", func(c *fiber.Ctx) error {
 		apiKey, err := getSessionApiKey(c, store)
 		if err != nil {
 			log.Errorf("Failed to get session api key: %v", err)
@@ -123,7 +109,14 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 			c.Response().SetBodyString(err.Error())
 			return c.SendStatus(500)
 		}
-		return c.JSON(issues)
+		type SpentTime struct {
+			TimeEnt *redmine.TimeEntryResponse `json:"time_spent"`
+			Issues  *redmine.IssuesRes         `json:"issues"`
+		}
+		var spent SpentTime
+		spent.TimeEnt = timeEntries
+		spent.Issues = issues
+		return c.JSON(spent)
 	})
 
 	app.Post("/api/report", func(c *fiber.Ctx) error {

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -110,12 +110,12 @@ func Setup(redmineConf cfg.RedmineConfig) *fiber.App {
 			return c.SendStatus(500)
 		}
 		type SpentTime struct {
-			TimeEnt *redmine.TimeEntryResponse `json:"time_spent"`
-			Issues  *redmine.IssuesRes         `json:"issues"`
+			TimeEnt []redmine.FetchedTimeEntry `json:"time_spent"`
+			Issues  []redmine.Issue            `json:"issues"`
 		}
 		var spent SpentTime
-		spent.TimeEnt = timeEntries
-		spent.Issues = issues
+		spent.TimeEnt = timeEntries.TimeEntries
+		spent.Issues = issues.Issues
 		return c.JSON(spent)
 	})
 

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -64,7 +64,7 @@ type TimeEntry struct {
 	Comments string `json:"comments"`
 	User     int    `json:"user_id"`
 }
-type timeEntryResponse struct {
+type TimeEntryResponse struct {
 	TimeEntries []FetchedTimeEntry `json:"time_entries"`
 }
 
@@ -161,7 +161,7 @@ func GetIssues(redmineConf cfg.RedmineConfig, apiKey string, issueIds []string) 
 	return r, err
 }
 
-func GetTimeEntries(redmineConf cfg.RedmineConfig, apiKey string, dayFrom string, dayTo string) (*timeEntryResponse, error) {
+func GetTimeEntries(redmineConf cfg.RedmineConfig, apiKey string, dayFrom string, dayTo string) (*TimeEntryResponse, error) {
 	_, err := time.Parse("2006-01-02", dayFrom)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func GetTimeEntries(redmineConf cfg.RedmineConfig, apiKey string, dayFrom string
 	res, err :=
 		doRequest(redmineConf, "GET", fmt.Sprintf("/time_entries.json?user_id=me&from=%s&to=%s", dayFrom, dayTo), map[string]string{"X-Redmine-API-Key": apiKey}, "")
 
-	r := &timeEntryResponse{}
+	r := &TimeEntryResponse{}
 
 	if err != nil {
 		return r, err


### PR DESCRIPTION
This solution serves both issues and spent time from a single endpoint called `spent_time`.

This might be tested after logging in by browsing to:

localhost:8080/api/spent_time?start=2022-01-01&end=2022-03-01

