### PR TITLE
Fix/linter issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,7 @@ jobs:
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
           # args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck
+          args: --timeout=5m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,9 +1,17 @@
 name: golangci-lint
 on:
   push:
-    branches-ignore: [main, develop]
+    branches-ignore:
+      - main
+      - develop
+    paths:
+      - 'backend/**'
   pull_request:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
+    paths:
+      - 'backend/**'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
1. Increase Go linter timeout to 5 minutes.
2. Only run Go linter if modifying files under `backend`.

Closes #128 