### PR TITLE
Enabling timelogging for whole week

### DIFF
--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -26,7 +26,9 @@ export const Cell = ({
   return (
     <div className="col-1">
       <label
-        htmlFor={`${recentIssue.issue.id}${recentIssue.activity.id}`}
+        htmlFor={`${recentIssue.issue.id}${
+          recentIssue.activity.id
+        }${date.toISOString()}`}
         hidden={true}
       >
         Time spent on{" "}
@@ -35,7 +37,9 @@ export const Cell = ({
       </label>
       <input
         type="number"
-        id={`${recentIssue.issue.id}${recentIssue.activity.id}`}
+        id={`${recentIssue.issue.id}${
+          recentIssue.activity.id
+        }${date.toISOString()}`}
         min={0}
         onChange={(event: any) => passTimeEntry(+event.target.value)}
         className="cell"

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -5,24 +5,15 @@ export const Cell = ({
   recentIssue,
   date,
   userId,
+  entry,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   date: Date;
   userId: number;
+  entry: TimeEntry;
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
-  const passTimeEntry = (hours: number) => {
-    let newEntry: TimeEntry = {
-      issue_id: recentIssue.issue.id,
-      activity_id: recentIssue.activity.id,
-      hours: hours,
-      comments: "",
-      spent_on: date.toISOString().split("T")[0],
-      user_id: userId,
-    };
-    onCellUpdate(newEntry);
-  };
   return (
     <div className="col-1">
       <label
@@ -41,8 +32,18 @@ export const Cell = ({
           recentIssue.activity.id
         }${date.toISOString()}`}
         min={0}
-        onChange={(event: any) => passTimeEntry(+event.target.value)}
+        onChange={(event: any) => {
+          onCellUpdate({
+            issue_id: recentIssue.issue.id,
+            activity_id: recentIssue.activity.id,
+            hours: +event.target.value,
+            comments: "",
+            spent_on: date.toISOString().split("T")[0],
+            user_id: userId,
+          });
+        }}
         className="cell"
+        value={entry?.hours}
       />
     </div>
   );

--- a/frontend/src/components/HeaderRow.tsx
+++ b/frontend/src/components/HeaderRow.tsx
@@ -1,16 +1,13 @@
 import React from "react";
 
-export const HeaderRow = ({
-  title,
-  days,
-}: {
-  title: string;
-  days: string[];
-}) => {
+export const HeaderRow = ({ title, days }: { title: string; days: Date[] }) => {
+  const dayStrings = days.map((day) => {
+    return day.toISOString().split("T")[0];
+  });
   return (
     <div className="row">
       <h2 className="col-6">{title}</h2>
-      {days.map((day) => {
+      {dayStrings.map((day) => {
         return (
           <p key={day} className="col-1">
             {day}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -19,12 +19,19 @@ export const Row = ({
         <p className="col-6 issue-label">
           {recentIssue.issue.subject} - {recentIssue.activity.name}
         </p>
-        <Cell
-          recentIssue={recentIssue}
-          date={days[0]}
-          onCellUpdate={onCellUpdate}
-          userId={userId}
-        />
+        {days.map((day) => {
+          return (
+            <Cell
+              key={`${recentIssue.issue.id}${
+                recentIssue.activity.id
+              }${day.toISOString()}`}
+              recentIssue={recentIssue}
+              date={day}
+              onCellUpdate={onCellUpdate}
+              userId={userId}
+            />
+          );
+        })}
       </div>
     </>
   );

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -6,11 +6,13 @@ export const Row = ({
   recentIssue,
   days,
   userId,
+  rowEntries,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   days: Date[];
   userId: number;
+  rowEntries: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   return (
@@ -20,6 +22,9 @@ export const Row = ({
           {recentIssue.issue.subject} - {recentIssue.activity.name}
         </p>
         {days.map((day) => {
+          const currentEntry = rowEntries?.find(
+            (entry) => entry.spent_on === day.toISOString().split("T")[0]
+          );
           return (
             <Cell
               key={`${recentIssue.issue.id}${
@@ -29,6 +34,7 @@ export const Row = ({
               date={day}
               onCellUpdate={onCellUpdate}
               userId={userId}
+              entry={currentEntry}
             />
           );
         })}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -18,9 +18,11 @@ export const Row = ({
   return (
     <>
       <div className="row issue-row">
-        <p className="col-6 issue-label">
-          {recentIssue.issue.subject} - {recentIssue.activity.name}
-        </p>
+        <div className="col-6 ">
+          <p className="issue-label">
+            {recentIssue.issue.subject} - {recentIssue.activity.name}
+          </p>
+        </div>
         {days.map((day) => {
           const currentEntry = rowEntries?.find(
             (entry) => entry.spent_on === day.toISOString().split("T")[0]

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,7 +11,6 @@ body {
 h2 {
   font-size: 1.25rem;
   font-weight: 700;
-  margin: 0 2.25rem 0 0;
 }
 
 /* HIDING ARROWS IN NUMBER INPUT FIELDS */
@@ -83,14 +82,13 @@ input[type="number"] {
 }
 
 .issue-row {
-  margin: 1.25rem 4.5rem;
-  align-items: center;
+  padding: 0.75rem 0;
 }
 
 .issue-label {
   background-color: white;
   padding: 0.5rem 0.75rem;
-  margin: 0 2.25rem 0 0;
+  margin: 0 2.25rem 0 3.75rem;
 }
 
 .save-button {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -161,10 +161,7 @@ export const Report = () => {
   return (
     <>
       <section className="recent-container">
-        <HeaderRow
-          days={[today.toISOString().split("T")[0]]}
-          title="Recent issues"
-        />
+        <HeaderRow days={thisWeek} title="Recent issues" />
         {recentIssues.map((issue) => {
           return (
             <>

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -118,7 +118,9 @@ export const Report = () => {
   }, []);
 
   const handleCellUpdate = (timeEntry: TimeEntry): void => {
-    const entries = newTimeEntries;
+    const entries = newTimeEntries.map((entry) => {
+      return entry;
+    });
     const existingEntry = entries.find(
       (entry) =>
         entry.issue_id === timeEntry.issue_id &&
@@ -163,13 +165,20 @@ export const Report = () => {
       <section className="recent-container">
         <HeaderRow days={thisWeek} title="Recent issues" />
         {recentIssues.map((issue) => {
+          const rowEntries = newTimeEntries?.filter(
+            (entry) =>
+              entry.issue_id === issue.issue.id &&
+              entry.activity_id === issue.activity.id
+          );
           return (
             <>
               <Row
+                key={`${issue.issue.id}${issue.activity.id}`}
                 recentIssue={issue}
                 onCellUpdate={handleCellUpdate}
                 days={thisWeek}
                 userId={user.user_id}
+                rowEntries={rowEntries}
               />
             </>
           );

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -60,6 +60,36 @@ export const Report = () => {
   headers.set("Content-Type", "application/json");
 
   const today = new Date();
+  const addDays = (date: Date, days: number) => {
+    let result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+  };
+  const getFullWeek = (today: Date): Date[] => {
+    let fullWeek = [];
+    const todayDay = today.getDay(); // Sunday - Saturday : 0 - 6
+    let days = [];
+    if (todayDay === 0) {
+      days = [-6, -5, -4, -3, -2];
+    } else if (todayDay === 1) {
+      days = [0, 1, 2, 3, 4];
+    } else if (todayDay === 2) {
+      days = [-1, 0, 1, 2, 3];
+    } else if (todayDay === 3) {
+      days = [-2, -1, 0, 1, 2];
+    } else if (todayDay === 4) {
+      days = [-3, -2, -1, 0, 1];
+    } else if (todayDay === 5) {
+      days = [-4, -3, -2, -1, 0];
+    } else if (todayDay === 6) {
+      days = [-5, -4, -3, -2, -1];
+    }
+    days.forEach((day) => {
+      fullWeek.push(addDays(today, day));
+    });
+    return fullWeek;
+  };
+  const thisWeek = getFullWeek(today);
 
   const getRecentIssues = async () => {
     let issues: RecentIssue[] = await fetch(
@@ -141,7 +171,7 @@ export const Report = () => {
               <Row
                 recentIssue={issue}
                 onCellUpdate={handleCellUpdate}
-                days={[today]}
+                days={thisWeek}
                 userId={user.user_id}
               />
             </>


### PR DESCRIPTION
The interface now shows input cells for the whole week instead of one day. 
It will always show Monday to Friday of the current week, starting with Monday.
It's possible to add time entries in several input cells and save them with one click on the "Save changes"-button.

Limitations:
- there is still no proper error handling / input validation yet
- no existing time entries are fetched from the backend. Thus it's only possible to add new entries (not editing or deleting existing ones).

This fixes #145 .