### PR TITLE
Feature/make spent time project specific

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -70,9 +70,9 @@ func Setup() *fiber.App {
 
 	app.Get("/api/recent_issues", recentIssuesHandler)
 
-	app.Get("/api/spent_time", spentTimeWithinDateRangeHandler)
+	app.Get("/api/time_entries", getTimeEntriesHandler)
 
-	app.Post("/api/report", timeReportHandler)
+	app.Post("/api/time_entries", postTimeEntriesHandler)
 
 	// 404 Handler
 	app.Use(func(c *fiber.Ctx) error {

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -202,7 +202,7 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 		return c.SendStatus(500)
 	}
 
-	return c.JSON(timeEntries)
+	return c.JSON(timeEntries.TimeEntries)
 }
 
 // postTimeEntriesHandler godoc

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -181,8 +181,9 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	// Add the API key to the headers.
 	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me",
-		config.Config.Redmine.Host, config.Config.Redmine.Port)
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?%s",
+		config.Config.Redmine.Host, config.Config.Redmine.Port,
+		c.Request().URI().QueryString())
 
 	// Proxy the request to Redmine
 	return proxy.Do(c, redmineURL)

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -177,6 +177,8 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 // @Param Cookie header string true "default"
 // @Param start_date query string true "start date"
 // @Param end_date query string true "end date"
+// @Param project_id query int true "Redmine project ID"
+// @Param activity_id query int true "Redmine activity ID"
 // @Accept  json
 // @Produce  json
 // @Success 200 {array} SpentOnIssueActivityResponse
@@ -191,8 +193,10 @@ func spentTimeWithinDateRangeHandler(c *fiber.Ctx) error {
 	}
 	startDate := c.Query("start_date", defaultDate)
 	endDate := c.Query("end_date", defaultDate)
+	projectId := c.Query("project_id")
+	activityId := c.Query("activity_id")
 
-	timeEntries, err := redmine.GetTimeEntriesWithinDateRange(user.ApiKey, startDate, endDate)
+	timeEntries, err := redmine.GetTimeEntriesFiltered(user.ApiKey, startDate, endDate, projectId, activityId)
 	if err != nil {
 		log.Errorf("Failed to get recent entries: %v", err)
 		return c.SendStatus(500)

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -181,7 +181,7 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	// Add the API key to the headers.
 	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?%s",
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me&%s",
 		config.Config.Redmine.Host, config.Config.Redmine.Port,
 		c.Request().URI().QueryString())
 

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -122,7 +122,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 		log.Errorf("Failed to get session: %v", err)
 		return c.SendStatus(401)
 	}
-	timeEntries, err := redmine.GetTimeEntries(user.ApiKey,nil,nil,nil,nil)
+	timeEntries, err := redmine.GetTimeEntries(user.ApiKey, nil, nil, nil, nil)
 	if err != nil {
 		log.Errorf("Failed to get recent entries: %v", err)
 		c.Response().SetBodyString(err.Error())
@@ -183,7 +183,7 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	}
 	var endDate *string
 	if endDateStr != "" {
-		endDate =  &endDateStr
+		endDate = &endDateStr
 	}
 	var issueId *int
 	if issueIdStr != "" {

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -157,11 +157,12 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 }
 
 // getTimeEntriesHandler godoc
-// @Summary get time entries for an issue+activity within a given time period
-// @Description get time entries within start and end dates
+// @Summary Proxy for the "/time_entries.json" Redmine endpoint
+// @Description get time entries
 // @Param Cookie header string true "default"
-// @Param start_date query string false "start date"
-// @Param end_date query string false "end date"
+// @Param from query string false "start date"
+// @Param to query string false "end date"
+// @Param spent_on string false "date"
 // @Param issue_id query int false "Redmine issue ID"
 // @Param activity_id query int false "Redmine activity ID"
 // @Accept  json
@@ -178,10 +179,10 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	}
 
 	// Add the API key to the headers.
-	c.Set("X-Redmine-API-Key", user.ApiKey)
+	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("http://%s:%s/time_entries.json?user_id=%d",
-		config.Config.Redmine.Host, config.Config.Redmine.Port, user.Id)
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me",
+		config.Config.Redmine.Host, config.Config.Redmine.Port)
 
 	// Proxy the request to Redmine
 	return proxy.Do(c, redmineURL)

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -10,8 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const defaultDate = "1970-01-01"
-
 type LoginResponse struct {
 	Login  string `json:"login"`
 	UserId int    `json:"user_id"`
@@ -53,23 +51,6 @@ func getIssueActivityPairs(issues *redmine.IssuesRes, issueActivities []IssueAct
 				Activity: issueAct.Activity})
 	}
 	return recentIssues
-
-}
-
-func getSpentOnIssueActivities(issues *redmine.IssuesRes, issueActivities []SpentOnIssueActivity) []SpentOnIssueActivityResponse {
-	issuesMap := make(map[int]redmine.Issue)
-	for _, issue := range issues.Issues {
-		issuesMap[issue.Id] = issue
-	}
-
-	var timeSpent []SpentOnIssueActivityResponse
-
-	for _, issueAct := range issueActivities {
-		timeSpent = append(timeSpent,
-			SpentOnIssueActivityResponse{Issue: issuesMap[issueAct.Issue],
-				Activity: issueAct.Activity, Hours: issueAct.Hours, SpentOn: issueAct.SpentOn})
-	}
-	return timeSpent
 
 }
 
@@ -126,7 +107,7 @@ func logoutHandler(c *fiber.Ctx) error {
 }
 
 // recentIssuesHandler godoc
-// @Summary get recent issues
+// @Summary get issues that the user has spent time on
 // @Description get recent issues
 // @Param Cookie header string true "default"
 // @Accept  json

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -162,7 +162,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 // @Param activity_id query int false "Redmine activity ID"
 // @Accept  json
 // @Produce  json
-// @Success 200 {array} FetchedTimeEntry
+// @Success 200 {array} redmine.FetchedTimeEntry
 // @Failure 401 {string} error "Unauthorized"
 // @Failure 500 {string} error "Internal Server Error"
 // @Router /api/time_entries [get]

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -59,7 +59,7 @@ type timeEntryRequest struct {
 type TimeEntry struct {
 	Issue    int    `json:"issue_id"`
 	SpentOn  string `json:"spent_on"`
-	Hours    int    `json:"hours"`
+	Hours    float32    `json:"hours"`
 	Activity int    `json:"activity_id"`
 	Comments string `json:"comments"`
 	User     int    `json:"user_id"`

--- a/backend/internal/redmine/api.go
+++ b/backend/internal/redmine/api.go
@@ -57,12 +57,12 @@ type timeEntryRequest struct {
 }
 
 type TimeEntry struct {
-	Issue    int    `json:"issue_id"`
-	SpentOn  string `json:"spent_on"`
-	Hours    float32    `json:"hours"`
-	Activity int    `json:"activity_id"`
-	Comments string `json:"comments"`
-	User     int    `json:"user_id"`
+	Issue    int     `json:"issue_id"`
+	SpentOn  string  `json:"spent_on"`
+	Hours    float32 `json:"hours"`
+	Activity int     `json:"activity_id"`
+	Comments string  `json:"comments"`
+	User     int     `json:"user_id"`
 }
 type TimeEntryResponse struct {
 	TimeEntries []FetchedTimeEntry `json:"time_entries"`
@@ -196,7 +196,7 @@ func GetTimeEntries(apiKey string,
 	}
 	defer res.Body.Close()
 
-	response := &TimeEntryResponse{};
+	response := &TimeEntryResponse{}
 	decoder := json.NewDecoder(res.Body)
 	err = decoder.Decode(&response)
 

--- a/backend/internal/redmine/api_test.go
+++ b/backend/internal/redmine/api_test.go
@@ -133,7 +133,7 @@ func TestGetTimeEntries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := GetTimeEntries(tt.args.apiKey)
+			resp, err := GetTimeEntries(tt.args.apiKey,nil,nil,nil,nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTimeEntries() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -196,7 +196,7 @@ func TestGetTimeEntriesWithinDateRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := GetTimeEntriesWithinDateRange(tt.args.apiKey, tt.args.dayFrom, tt.args.dayTo)
+			resp, err := GetTimeEntries(tt.args.apiKey, &tt.args.dayFrom, &tt.args.dayTo,nil,nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTimeEntriesWithinDateRange() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/backend/internal/redmine/api_test.go
+++ b/backend/internal/redmine/api_test.go
@@ -133,7 +133,7 @@ func TestGetTimeEntries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := GetTimeEntries(tt.args.apiKey,nil,nil,nil,nil)
+			resp, err := GetTimeEntries(tt.args.apiKey, nil, nil, nil, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTimeEntries() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -196,7 +196,7 @@ func TestGetTimeEntriesWithinDateRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := GetTimeEntries(tt.args.apiKey, &tt.args.dayFrom, &tt.args.dayTo,nil,nil)
+			resp, err := GetTimeEntries(tt.args.apiKey, &tt.args.dayFrom, &tt.args.dayTo, nil, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTimeEntriesWithinDateRange() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -6,12 +6,14 @@ export const Cell = ({
   date,
   userId,
   hours,
+  entryId,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   date: Date;
   userId: number;
   hours: number;
+  entryId: number;
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   return (
@@ -34,6 +36,7 @@ export const Cell = ({
         min={0}
         onChange={(event: any) => {
           onCellUpdate({
+            id: entryId,
             issue_id: recentIssue.issue.id,
             activity_id: recentIssue.activity.id,
             hours: +event.target.value,

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -5,13 +5,13 @@ export const Cell = ({
   recentIssue,
   date,
   userId,
-  entry,
+  hours,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   date: Date;
   userId: number;
-  entry: TimeEntry;
+  hours: number;
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   return (
@@ -43,7 +43,7 @@ export const Cell = ({
           });
         }}
         className="cell"
-        value={entry?.hours}
+        value={hours}
       />
     </div>
   );

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -43,7 +43,7 @@ export const Cell = ({
           });
         }}
         className="cell"
-        value={hours}
+        value={hours === 0 ? "" : hours}
       />
     </div>
   );

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -28,7 +28,6 @@ export const Row = ({
   headers.set("Content-Type", "application/json");
 
   let params = new URLSearchParams({
-    user_id: `me`,
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
     from: `${days[0].toISOString().split("T")[0]}`,

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -28,10 +28,11 @@ export const Row = ({
   headers.set("Content-Type", "application/json");
 
   let params = new URLSearchParams({
+    user_id: `me`,
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
-    start_date: `${days[0].toISOString().split("T")[0]}`,
-    end_date: `${days[4].toISOString().split("T")[0]}`,
+    from: `${days[0].toISOString().split("T")[0]}`,
+    to: `${days[4].toISOString().split("T")[0]}`,
   });
 
   const getTimeEntries = async (params: URLSearchParams) => {

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,3 +1,4 @@
+import.meta.hot;
 import React, { useState } from "react";
 import { RecentIssue, TimeEntry, FetchedTimeEntry } from "../pages/Report";
 import { Cell } from "./Cell";
@@ -22,6 +23,7 @@ export const Row = ({
   const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
   const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
   const [rowEntryIds, setRowEntryIds] = useState<number[]>([]);
+  const { SNOWPACK_PUBLIC_API_URL } = __SNOWPACK_ENV__;
 
   let headers = new Headers();
   headers.set("Accept", "application/json");
@@ -36,7 +38,7 @@ export const Row = ({
 
   const getTimeEntries = async (params: URLSearchParams) => {
     let entries: { time_entries: FetchedTimeEntry[] } = await fetch(
-      `http://localhost:8080/api/time_entries?${params}`,
+      `${SNOWPACK_PUBLIC_API_URL}/api/time_entries?${params}`,
       {
         method: "GET",
         credentials: "include",

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { RecentIssue, TimeEntry } from "../pages/Report";
+import { RecentIssue, TimeEntry, FetchedTimeEntry } from "../pages/Report";
 import { Cell } from "./Cell";
 
 export const Row = ({
@@ -15,7 +15,7 @@ export const Row = ({
   rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
-  const [rowEntries, setRowEntries] = useState<TimeEntry[]>([]);
+  const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
   let headers = new Headers();
   headers.set("Accept", "application/json");
   headers.set("Content-Type", "application/json");
@@ -25,7 +25,7 @@ export const Row = ({
     startDate: string,
     endDate: string
   ) => {
-    let entries: TimeEntry[] = await fetch(
+    let entries: FetchedTimeEntry[] = await fetch(
       "http://localhost:8080/api/spent_time",
       {
         method: "GET",
@@ -47,7 +47,7 @@ export const Row = ({
 
   const findCurrentHours = (day: Date) => {
     let hours = 0;
-    let entry = rowUpdates?.find(
+    let entry: TimeEntry | FetchedTimeEntry = rowUpdates?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
     );
     if (!entry) {
@@ -60,6 +60,17 @@ export const Row = ({
     }
     return hours;
   };
+
+  const findEntryId = (day: Date) => {
+    let id = 0;
+    let entry = rowEntries?.find(
+      (entry) => entry.spent_on === day.toISOString().split("T")[0]
+    );
+    if (entry) {
+      id = entry.id;
+    }
+    return id;
+  };
   return (
     <>
       <div className="row issue-row">
@@ -70,6 +81,7 @@ export const Row = ({
         </div>
         {days.map((day) => {
           const hours = findCurrentHours(day);
+          const id = findEntryId(day);
           return (
             <Cell
               key={`${recentIssue.issue.id}${
@@ -80,6 +92,7 @@ export const Row = ({
               onCellUpdate={onCellUpdate}
               userId={userId}
               hours={hours}
+              entryId={id}
             />
           );
         })}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -16,25 +16,27 @@ export const Row = ({
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
-  const [rowHours, setRowHours] = useState<number[]>([]);
+  const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
   const [rowEntryIds, setRowEntryIds] = useState<number[]>([]);
+
   let headers = new Headers();
   headers.set("Accept", "application/json");
   headers.set("Content-Type", "application/json");
+
   let params = new URLSearchParams({
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
-    start_date: `2022-03-07`,
-    end_date: `2022-03-11`,
+    start_date: `${days[0].toISOString().split("T")[0]}`,
+    end_date: `${days[4].toISOString().split("T")[0]}`,
   });
+
   const getTimeEntries = async (params: URLSearchParams) => {
-    let entries: FetchedTimeEntry[] = await fetch(
+    let entries: { time_entries: FetchedTimeEntry[] } = await fetch(
       `http://localhost:8080/api/time_entries?${params}`,
       {
         method: "GET",
         credentials: "include",
         headers: headers,
-        //we somehow need to send id's and date's here
       }
     )
       .then((res) => {
@@ -48,17 +50,17 @@ export const Row = ({
       .catch((error) => console.log(error));
     setRowEntries(entries.time_entries);
   };
+
   React.useEffect(() => {
     getTimeEntries(params);
   }, []);
 
   const findCurrentHours = (day: Date) => {
-    console.log("finding hours", rowEntries);
     let hours = 0;
     let entry: TimeEntry | FetchedTimeEntry = rowUpdates?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
     );
-    if (!entry) {
+    if (!entry && rowEntries && rowEntries.length > 0) {
       entry = rowEntries?.find(
         (entry) => entry.spent_on === day.toISOString().split("T")[0]
       );
@@ -69,19 +71,7 @@ export const Row = ({
     return hours;
   };
 
-  React.useEffect(() => {
-    console.log("use effect");
-    if (rowEntries && rowEntries.length > 0) {
-      console.log("if true");
-      const hours = days.map((day) => findCurrentHours(day));
-      setRowHours(hours);
-      const entryIds = days.map((day) => findEntryId(day));
-      setRowEntryIds(entryIds);
-    }
-  }, [rowEntries, rowUpdates]);
-
   const findEntryId = (day: Date) => {
-    console.log("finding entry", rowEntries);
     let id = 0;
     let entry = rowEntries?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
@@ -91,6 +81,14 @@ export const Row = ({
     }
     return id;
   };
+
+  React.useEffect(() => {
+    const hours = days.map((day) => findCurrentHours(day));
+    setRowHours(hours);
+    const entryIds = days.map((day) => findEntryId(day));
+    setRowEntryIds(entryIds);
+  }, [rowEntries, rowUpdates]);
+
   return (
     <>
       <div className="row issue-row">

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { RecentIssue, TimeEntry } from "../pages/Report";
 import { Cell } from "./Cell";
 
@@ -6,15 +6,60 @@ export const Row = ({
   recentIssue,
   days,
   userId,
-  rowEntries,
+  rowUpdates,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   days: Date[];
   userId: number;
-  rowEntries: TimeEntry[];
+  rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
+  const [rowEntries, setRowEntries] = useState<TimeEntry[]>([]);
+  let headers = new Headers();
+  headers.set("Accept", "application/json");
+  headers.set("Content-Type", "application/json");
+  const getTimeEntries = async (
+    issueId: number,
+    activityId: number,
+    startDate: string,
+    endDate: string
+  ) => {
+    let entries: TimeEntry[] = await fetch(
+      "http://localhost:8080/api/spent_time",
+      {
+        method: "GET",
+        credentials: "include",
+        headers: headers,
+        //we somehow need to send id's and date's here
+      }
+    )
+      .then((res) => {
+        if (res.ok) {
+          return res.json();
+        } else {
+          throw new Error("Could not get time entries.");
+        }
+      })
+      .catch((error) => console.log(error));
+    setRowEntries(entries);
+  };
+
+  const findCurrentHours = (day: Date) => {
+    let hours = 0;
+    let entry = rowUpdates?.find(
+      (entry) => entry.spent_on === day.toISOString().split("T")[0]
+    );
+    if (!entry) {
+      entry = rowEntries?.find(
+        (entry) => entry.spent_on === day.toISOString().split("T")[0]
+      );
+    }
+    if (entry) {
+      hours = entry.hours;
+    }
+    return hours;
+  };
   return (
     <>
       <div className="row issue-row">
@@ -24,9 +69,7 @@ export const Row = ({
           </p>
         </div>
         {days.map((day) => {
-          const currentEntry = rowEntries?.find(
-            (entry) => entry.spent_on === day.toISOString().split("T")[0]
-          );
+          const hours = findCurrentHours(day);
           return (
             <Cell
               key={`${recentIssue.issue.id}${
@@ -36,7 +79,7 @@ export const Row = ({
               date={day}
               onCellUpdate={onCellUpdate}
               userId={userId}
-              entry={currentEntry}
+              hours={hours}
             />
           );
         })}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -8,12 +8,16 @@ export const Row = ({
   userId,
   rowUpdates,
   onCellUpdate,
+  onReset,
+  saved,
 }: {
   recentIssue: RecentIssue;
   days: Date[];
   userId: number;
   rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
+  onReset: () => void;
+  saved: boolean;
 }) => {
   const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
   const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
@@ -49,11 +53,12 @@ export const Row = ({
       })
       .catch((error) => console.log(error));
     setRowEntries(entries.time_entries);
+    setTimeout(() => onReset(), 100);
   };
 
   React.useEffect(() => {
     getTimeEntries(params);
-  }, []);
+  }, [saved]);
 
   const findCurrentHours = (day: Date) => {
     let hours = 0;

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -168,7 +168,7 @@ export const Report = () => {
         <HeaderRow days={thisWeek} title="Recent issues" />
         {recentIssues &&
           recentIssues.map((issue) => {
-            const rowEntries = newTimeEntries?.filter(
+            const rowUpdates = newTimeEntries?.filter(
               (entry) =>
                 entry.issue_id === issue.issue.id &&
                 entry.activity_id === issue.activity.id
@@ -181,7 +181,7 @@ export const Report = () => {
                   onCellUpdate={handleCellUpdate}
                   days={thisWeek}
                   userId={user.user_id}
-                  rowEntries={rowEntries}
+                  rowUpdates={rowUpdates}
                 />
               </>
             );

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -71,6 +71,7 @@ export interface FetchedTimeEntry {
 export const Report = () => {
   const [recentIssues, setRecentIssues] = useState<RecentIssue[]>([]);
   const [newTimeEntries, setNewTimeEntries] = useState<TimeEntry[]>([]);
+  const [toggleSave, setToggleSave] = useState(false);
   let location = useLocation();
   const user: User = location.state as User;
   const { SNOWPACK_PUBLIC_API_URL } = __SNOWPACK_ENV__;
@@ -165,7 +166,6 @@ export const Report = () => {
       .then((response) => {
         if (response.ok) {
           console.log("Time reported");
-          setNewTimeEntries([]);
           alert("Changes saved!");
         } else {
           throw new Error("Time report failed.");
@@ -178,12 +178,18 @@ export const Report = () => {
     newTimeEntries.forEach((entry) => {
       reportTime(entry);
     });
+    setToggleSave(!toggleSave);
+  };
+
+  const handleReset = () => {
+    setNewTimeEntries([]);
   };
 
   return (
     <>
       <section className="recent-container">
         <HeaderRow days={thisWeek} title="Recent issues" />
+<<<<<<< HEAD
         {recentIssues &&
           recentIssues.map((issue) => {
             const rowUpdates = newTimeEntries?.filter(
@@ -204,6 +210,29 @@ export const Report = () => {
               </>
             );
           })}
+=======
+        {recentIssues.map((issue) => {
+          const rowUpdates = newTimeEntries?.filter(
+            (entry) =>
+              entry.issue_id === issue.issue.id &&
+              entry.activity_id === issue.activity.id
+          );
+          return (
+            <>
+              <Row
+                key={`${issue.issue.id}${issue.activity.id}`}
+                recentIssue={issue}
+                onCellUpdate={handleCellUpdate}
+                onReset={handleReset}
+                saved={toggleSave}
+                days={thisWeek}
+                userId={user.user_id}
+                rowUpdates={rowUpdates}
+              />
+            </>
+          );
+        })}
+>>>>>>> f7c6ef2 (remove number flickering on save)
       </section>
       <button
         className="save-button"

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -205,6 +205,8 @@ export const Report = () => {
                   days={thisWeek}
                   userId={user.user_id}
                   rowUpdates={rowUpdates}
+                  onReset={handleReset}
+                  saved={toggleSave}
                 />
               </>
             );

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -7,6 +7,10 @@ import { User } from "../pages/Login";
 
 // interfaces use snake case to follow Redmines variable names
 
+export interface Id {
+  id: number;
+}
+
 export interface IdName {
   id: number;
   name: string;
@@ -42,12 +46,26 @@ export interface Issue {
 }
 
 export interface TimeEntry {
+  id: number;
   issue_id: number;
   activity_id: number;
   hours: number;
   comments: string;
   spent_on: string;
   user_id: number;
+}
+
+export interface FetchedTimeEntry {
+  id: number;
+  project: IdName;
+  issue: Id;
+  user: IdName;
+  activity: IdName;
+  hours: number;
+  comments: string;
+  spent_on: string;
+  created_on: string;
+  updated_on: string;
 }
 
 export const Report = () => {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -189,7 +189,6 @@ export const Report = () => {
     <>
       <section className="recent-container">
         <HeaderRow days={thisWeek} title="Recent issues" />
-<<<<<<< HEAD
         {recentIssues &&
           recentIssues.map((issue) => {
             const rowUpdates = newTimeEntries?.filter(
@@ -210,29 +209,6 @@ export const Report = () => {
               </>
             );
           })}
-=======
-        {recentIssues.map((issue) => {
-          const rowUpdates = newTimeEntries?.filter(
-            (entry) =>
-              entry.issue_id === issue.issue.id &&
-              entry.activity_id === issue.activity.id
-          );
-          return (
-            <>
-              <Row
-                key={`${issue.issue.id}${issue.activity.id}`}
-                recentIssue={issue}
-                onCellUpdate={handleCellUpdate}
-                onReset={handleReset}
-                saved={toggleSave}
-                days={thisWeek}
-                userId={user.user_id}
-                rowUpdates={rowUpdates}
-              />
-            </>
-          );
-        })}
->>>>>>> f7c6ef2 (remove number flickering on save)
       </section>
       <button
         className="save-button"

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -157,7 +157,7 @@ export const Report = () => {
   };
 
   const reportTime = (timeEntry: TimeEntry) => {
-    fetch(`${SNOWPACK_PUBLIC_API_URL}/api/report`, {
+    fetch(`${SNOWPACK_PUBLIC_API_URL}/api/time_entries`, {
       body: JSON.stringify(timeEntry),
       method: "POST",
       credentials: "include",


### PR DESCRIPTION
This PR is refactoring, and it enables the frontend to fetch time entries for a specific time frame for a particular issue and activity.

All endpoints that access the Redmine `/time_entires.json` endpoint are now called `/api/time_entries`. The backend proxies the request to Redmine, so the parameters for calling endpoint to _get_ data are as described in the [Redmine REST API documentation](https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries).

All of the parameters are optional. This means that leaving out the `from` and `to` dates will fetch _all_ the time entries for a particular `issue_id`+`activity_id`. And leaving out the `issue_id`+`activity_id` will get all issues+activities for the given time. You will still want to use `/api/recent_issues` to get _unique_ issues (that endpoint has not been modified in this PR).

A result is a JSON object like this:
```json
{
  "time_entries": [
    {
      "id": 75689,
      "project": {
        "id": 5,
        "name": "Infrastructure"
      },
      "issue": {
        "id": 5937
      },
      "user": {
        "id": 75,
        "name": "Andreas Kähäri"
      },
      "activity": {
        "id": 9,
        "name": "Development"
      },
      "hours": 3,
      "comments": "",
      "spent_on": "2022-03-04",
      "created_on": "2022-03-04T10:09:42Z",
      "updated_on": "2022-03-04T10:09:42Z"
    }
  ]
}
```

Using the `/api/time_entries` endpoint to _post_ data will create a single time entry. This requires the parameters corresponding to the following structure:
```
type TimeEntry struct {
        Issue    int    `json:"issue_id"`
        SpentOn  string `json:"spent_on"`
        Hours    float32   `json:"hours"`
        Activity int    `json:"activity_id"`
        Comments string `json:"comments"`
        User     int    `json:"user_id"`
}
```

(note that the `user_id` parameter will not be needed as we keep track of that in the backend).

_Later_, this endpoint will also automatically _update_ time entries if given an additional time entry ID, and it will _delete_ time entries whose reported time is zero hours (but only if there is a time entry ID available, otherwise such time entries will just be ignored).
