### PR TITLE
A way of update the package-lock.json in the container

### DIFF
--- a/frontend/update-package-lock
+++ b/frontend/update-package-lock
@@ -1,0 +1,6 @@
+#!/bin/sh -eu
+
+docker build -f update-package-lock.docker -t update-package-lock .
+docker create --name extract update-package-lock
+docker cp extract:/home/node/package-lock.json .
+docker rm extract

--- a/frontend/update-package-lock.docker
+++ b/frontend/update-package-lock.docker
@@ -1,0 +1,8 @@
+FROM node:17.6-slim
+
+USER node
+
+WORKDIR /home/node
+COPY --chown=node:node package.json ./
+
+RUN npm install


### PR DESCRIPTION
Do like this 

update the dependencies or add dependency in package.json

run ./update-package-lock

git add package.lock and the newly created package-lock.json 
and push both changes to git.

@kusalananda The bash script might need to do some more clever stuff please have a look at it. 

@HenrikeW this will update the lock file to the latest packages according to the update rules in package.json 
it might not be what we want but if the rules are set ok it wont brake so it can be a good idea to get the latest changes?