### PR TITLE
UI support for existing entries

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -181,8 +181,9 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	// Add the API key to the headers.
 	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me",
-		config.Config.Redmine.Host, config.Config.Redmine.Port)
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?%s",
+		config.Config.Redmine.Host, config.Config.Redmine.Port,
+		c.Request().URI().QueryString())
 
 	// Proxy the request to Redmine
 	return proxy.Do(c, redmineURL)

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -181,7 +181,7 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	// Add the API key to the headers.
 	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?%s",
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me&%s",
 		config.Config.Redmine.Host, config.Config.Redmine.Port,
 		c.Request().URI().QueryString())
 

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -157,11 +157,12 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 }
 
 // getTimeEntriesHandler godoc
-// @Summary get time entries for an issue+activity within a given time period
-// @Description get time entries within start and end dates
+// @Summary Proxy for the "/time_entries.json" Redmine endpoint
+// @Description get time entries
 // @Param Cookie header string true "default"
-// @Param start_date query string false "start date"
-// @Param end_date query string false "end date"
+// @Param from query string false "start date"
+// @Param to query string false "end date"
+// @Param spent_on string false "date"
 // @Param issue_id query int false "Redmine issue ID"
 // @Param activity_id query int false "Redmine activity ID"
 // @Accept  json
@@ -178,10 +179,10 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 	}
 
 	// Add the API key to the headers.
-	c.Set("X-Redmine-API-Key", user.ApiKey)
+	c.Request().Header.Set("X-Redmine-API-Key", user.ApiKey)
 
-	redmineURL := fmt.Sprintf("http://%s:%s/time_entries.json?user_id=%d",
-		config.Config.Redmine.Host, config.Config.Redmine.Port, user.Id)
+	redmineURL := fmt.Sprintf("%s:%s/time_entries.json?user_id=me",
+		config.Config.Redmine.Host, config.Config.Redmine.Port)
 
 	// Proxy the request to Redmine
 	return proxy.Do(c, redmineURL)

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -6,12 +6,14 @@ export const Cell = ({
   date,
   userId,
   hours,
+  entryId,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   date: Date;
   userId: number;
   hours: number;
+  entryId: number;
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   return (
@@ -34,6 +36,7 @@ export const Cell = ({
         min={0}
         onChange={(event: any) => {
           onCellUpdate({
+            id: entryId,
             issue_id: recentIssue.issue.id,
             activity_id: recentIssue.activity.id,
             hours: +event.target.value,

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -5,13 +5,13 @@ export const Cell = ({
   recentIssue,
   date,
   userId,
-  entry,
+  hours,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   date: Date;
   userId: number;
-  entry: TimeEntry;
+  hours: number;
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   return (
@@ -43,7 +43,7 @@ export const Cell = ({
           });
         }}
         className="cell"
-        value={entry?.hours}
+        value={hours}
       />
     </div>
   );

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -43,7 +43,7 @@ export const Cell = ({
           });
         }}
         className="cell"
-        value={hours}
+        value={hours === 0 ? "" : hours}
       />
     </div>
   );

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -28,7 +28,6 @@ export const Row = ({
   headers.set("Content-Type", "application/json");
 
   let params = new URLSearchParams({
-    user_id: `me`,
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
     from: `${days[0].toISOString().split("T")[0]}`,

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -28,10 +28,11 @@ export const Row = ({
   headers.set("Content-Type", "application/json");
 
   let params = new URLSearchParams({
+    user_id: `me`,
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
-    start_date: `${days[0].toISOString().split("T")[0]}`,
-    end_date: `${days[4].toISOString().split("T")[0]}`,
+    from: `${days[0].toISOString().split("T")[0]}`,
+    to: `${days[4].toISOString().split("T")[0]}`,
   });
 
   const getTimeEntries = async (params: URLSearchParams) => {

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { RecentIssue, TimeEntry } from "../pages/Report";
+import { RecentIssue, TimeEntry, FetchedTimeEntry } from "../pages/Report";
 import { Cell } from "./Cell";
 
 export const Row = ({
@@ -15,7 +15,7 @@ export const Row = ({
   rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
-  const [rowEntries, setRowEntries] = useState<TimeEntry[]>([]);
+  const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
   let headers = new Headers();
   headers.set("Accept", "application/json");
   headers.set("Content-Type", "application/json");
@@ -25,7 +25,7 @@ export const Row = ({
     startDate: string,
     endDate: string
   ) => {
-    let entries: TimeEntry[] = await fetch(
+    let entries: FetchedTimeEntry[] = await fetch(
       "http://localhost:8080/api/spent_time",
       {
         method: "GET",
@@ -47,7 +47,7 @@ export const Row = ({
 
   const findCurrentHours = (day: Date) => {
     let hours = 0;
-    let entry = rowUpdates?.find(
+    let entry: TimeEntry | FetchedTimeEntry = rowUpdates?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
     );
     if (!entry) {
@@ -60,6 +60,17 @@ export const Row = ({
     }
     return hours;
   };
+
+  const findEntryId = (day: Date) => {
+    let id = 0;
+    let entry = rowEntries?.find(
+      (entry) => entry.spent_on === day.toISOString().split("T")[0]
+    );
+    if (entry) {
+      id = entry.id;
+    }
+    return id;
+  };
   return (
     <>
       <div className="row issue-row">
@@ -70,6 +81,7 @@ export const Row = ({
         </div>
         {days.map((day) => {
           const hours = findCurrentHours(day);
+          const id = findEntryId(day);
           return (
             <Cell
               key={`${recentIssue.issue.id}${
@@ -80,6 +92,7 @@ export const Row = ({
               onCellUpdate={onCellUpdate}
               userId={userId}
               hours={hours}
+              entryId={id}
             />
           );
         })}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -16,25 +16,27 @@ export const Row = ({
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
   const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
-  const [rowHours, setRowHours] = useState<number[]>([]);
+  const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
   const [rowEntryIds, setRowEntryIds] = useState<number[]>([]);
+
   let headers = new Headers();
   headers.set("Accept", "application/json");
   headers.set("Content-Type", "application/json");
+
   let params = new URLSearchParams({
     issue_id: `${recentIssue.issue.id}`,
     activity_id: `${recentIssue.activity.id}`,
-    start_date: `2022-03-07`,
-    end_date: `2022-03-11`,
+    start_date: `${days[0].toISOString().split("T")[0]}`,
+    end_date: `${days[4].toISOString().split("T")[0]}`,
   });
+
   const getTimeEntries = async (params: URLSearchParams) => {
-    let entries: FetchedTimeEntry[] = await fetch(
+    let entries: { time_entries: FetchedTimeEntry[] } = await fetch(
       `http://localhost:8080/api/time_entries?${params}`,
       {
         method: "GET",
         credentials: "include",
         headers: headers,
-        //we somehow need to send id's and date's here
       }
     )
       .then((res) => {
@@ -48,17 +50,17 @@ export const Row = ({
       .catch((error) => console.log(error));
     setRowEntries(entries.time_entries);
   };
+
   React.useEffect(() => {
     getTimeEntries(params);
   }, []);
 
   const findCurrentHours = (day: Date) => {
-    console.log("finding hours", rowEntries);
     let hours = 0;
     let entry: TimeEntry | FetchedTimeEntry = rowUpdates?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
     );
-    if (!entry) {
+    if (!entry && rowEntries && rowEntries.length > 0) {
       entry = rowEntries?.find(
         (entry) => entry.spent_on === day.toISOString().split("T")[0]
       );
@@ -69,19 +71,7 @@ export const Row = ({
     return hours;
   };
 
-  React.useEffect(() => {
-    console.log("use effect");
-    if (rowEntries && rowEntries.length > 0) {
-      console.log("if true");
-      const hours = days.map((day) => findCurrentHours(day));
-      setRowHours(hours);
-      const entryIds = days.map((day) => findEntryId(day));
-      setRowEntryIds(entryIds);
-    }
-  }, [rowEntries, rowUpdates]);
-
   const findEntryId = (day: Date) => {
-    console.log("finding entry", rowEntries);
     let id = 0;
     let entry = rowEntries?.find(
       (entry) => entry.spent_on === day.toISOString().split("T")[0]
@@ -91,6 +81,14 @@ export const Row = ({
     }
     return id;
   };
+
+  React.useEffect(() => {
+    const hours = days.map((day) => findCurrentHours(day));
+    setRowHours(hours);
+    const entryIds = days.map((day) => findEntryId(day));
+    setRowEntryIds(entryIds);
+  }, [rowEntries, rowUpdates]);
+
   return (
     <>
       <div className="row issue-row">

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { RecentIssue, TimeEntry } from "../pages/Report";
 import { Cell } from "./Cell";
 
@@ -6,15 +6,60 @@ export const Row = ({
   recentIssue,
   days,
   userId,
-  rowEntries,
+  rowUpdates,
   onCellUpdate,
 }: {
   recentIssue: RecentIssue;
   days: Date[];
   userId: number;
-  rowEntries: TimeEntry[];
+  rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
 }) => {
+  const [rowEntries, setRowEntries] = useState<TimeEntry[]>([]);
+  let headers = new Headers();
+  headers.set("Accept", "application/json");
+  headers.set("Content-Type", "application/json");
+  const getTimeEntries = async (
+    issueId: number,
+    activityId: number,
+    startDate: string,
+    endDate: string
+  ) => {
+    let entries: TimeEntry[] = await fetch(
+      "http://localhost:8080/api/spent_time",
+      {
+        method: "GET",
+        credentials: "include",
+        headers: headers,
+        //we somehow need to send id's and date's here
+      }
+    )
+      .then((res) => {
+        if (res.ok) {
+          return res.json();
+        } else {
+          throw new Error("Could not get time entries.");
+        }
+      })
+      .catch((error) => console.log(error));
+    setRowEntries(entries);
+  };
+
+  const findCurrentHours = (day: Date) => {
+    let hours = 0;
+    let entry = rowUpdates?.find(
+      (entry) => entry.spent_on === day.toISOString().split("T")[0]
+    );
+    if (!entry) {
+      entry = rowEntries?.find(
+        (entry) => entry.spent_on === day.toISOString().split("T")[0]
+      );
+    }
+    if (entry) {
+      hours = entry.hours;
+    }
+    return hours;
+  };
   return (
     <>
       <div className="row issue-row">
@@ -24,9 +69,7 @@ export const Row = ({
           </p>
         </div>
         {days.map((day) => {
-          const currentEntry = rowEntries?.find(
-            (entry) => entry.spent_on === day.toISOString().split("T")[0]
-          );
+          const hours = findCurrentHours(day);
           return (
             <Cell
               key={`${recentIssue.issue.id}${
@@ -36,7 +79,7 @@ export const Row = ({
               date={day}
               onCellUpdate={onCellUpdate}
               userId={userId}
-              entry={currentEntry}
+              hours={hours}
             />
           );
         })}

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -8,12 +8,16 @@ export const Row = ({
   userId,
   rowUpdates,
   onCellUpdate,
+  onReset,
+  saved,
 }: {
   recentIssue: RecentIssue;
   days: Date[];
   userId: number;
   rowUpdates: TimeEntry[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
+  onReset: () => void;
+  saved: boolean;
 }) => {
   const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
   const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
@@ -49,11 +53,12 @@ export const Row = ({
       })
       .catch((error) => console.log(error));
     setRowEntries(entries.time_entries);
+    setTimeout(() => onReset(), 100);
   };
 
   React.useEffect(() => {
     getTimeEntries(params);
-  }, []);
+  }, [saved]);
 
   const findCurrentHours = (day: Date) => {
     let hours = 0;

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -165,7 +165,7 @@ export const Report = () => {
       <section className="recent-container">
         <HeaderRow days={thisWeek} title="Recent issues" />
         {recentIssues.map((issue) => {
-          const rowEntries = newTimeEntries?.filter(
+          const rowUpdates = newTimeEntries?.filter(
             (entry) =>
               entry.issue_id === issue.issue.id &&
               entry.activity_id === issue.activity.id
@@ -178,7 +178,7 @@ export const Report = () => {
                 onCellUpdate={handleCellUpdate}
                 days={thisWeek}
                 userId={user.user_id}
-                rowEntries={rowEntries}
+                rowUpdates={rowUpdates}
               />
             </>
           );

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -6,6 +6,10 @@ import { User } from "../pages/Login";
 
 // interfaces use snake case to follow Redmines variable names
 
+export interface Id {
+  id: number;
+}
+
 export interface IdName {
   id: number;
   name: string;
@@ -41,12 +45,26 @@ export interface Issue {
 }
 
 export interface TimeEntry {
+  id: number;
   issue_id: number;
   activity_id: number;
   hours: number;
   comments: string;
   spent_on: string;
   user_id: number;
+}
+
+export interface FetchedTimeEntry {
+  id: number;
+  project: IdName;
+  issue: Id;
+  user: IdName;
+  activity: IdName;
+  hours: number;
+  comments: string;
+  spent_on: string;
+  created_on: string;
+  updated_on: string;
 }
 
 export const Report = () => {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -70,6 +70,7 @@ export interface FetchedTimeEntry {
 export const Report = () => {
   const [recentIssues, setRecentIssues] = useState<RecentIssue[]>([]);
   const [newTimeEntries, setNewTimeEntries] = useState<TimeEntry[]>([]);
+  const [toggleSave, setToggleSave] = useState(false);
   let location = useLocation();
   const user: User = location.state as User;
 
@@ -154,7 +155,7 @@ export const Report = () => {
   };
 
   const reportTime = (timeEntry: TimeEntry) => {
-    fetch("http://localhost:8080/api/report", {
+    fetch("http://localhost:8080/api/time_entries", {
       body: JSON.stringify(timeEntry),
       method: "POST",
       credentials: "include",
@@ -163,7 +164,6 @@ export const Report = () => {
       .then((response) => {
         if (response.ok) {
           console.log("Time reported");
-          setNewTimeEntries([]);
           alert("Changes saved!");
         } else {
           throw new Error("Time report failed.");
@@ -176,6 +176,11 @@ export const Report = () => {
     newTimeEntries.forEach((entry) => {
       reportTime(entry);
     });
+    setToggleSave(!toggleSave);
+  };
+
+  const handleReset = () => {
+    setNewTimeEntries([]);
   };
 
   return (
@@ -194,6 +199,8 @@ export const Report = () => {
                 key={`${issue.issue.id}${issue.activity.id}`}
                 recentIssue={issue}
                 onCellUpdate={handleCellUpdate}
+                onReset={handleReset}
+                saved={toggleSave}
                 days={thisWeek}
                 userId={user.user_id}
                 rowUpdates={rowUpdates}


### PR DESCRIPTION
OBS: This PR is based on the branch @kusalananda is working on. It adds the frontend part for handling existing time entries. 

The UI now shows all time entries for the user's recent issues in the corresponding cells. 
On save, all changes are saved. This can now be modified entries, deleted entries (sent as TimeEntry objects with 0 hours) or entirely new entries.

In case you wonder about the `setTimeout` in the Row component, line 56: without this, when saving, changed values would jump back to the old value for a short moment because of asynchronous fetching. This workaround removes the effect. 
If you have any better idea of solving the problem, please let me know! 
