### PR TITLE
Fix/documentation update

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -236,15 +236,14 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusUnprocessableEntity)
 	}
 
-	// Iterate over our issueActivities list
-	// and fill in the missing subject to each issue from the issuesResponse
-	// structure.
+	// Iterate over our issueActivities list and fill in the missing
+	// subject to each issue from the issuesResponse structure.
 
 	for i := range issueActivities {
 		for j := range issuesResponse.Issues {
-			if timeEntriesResponse.TimeEntries[j] == issueActivities[i] {
+			if issuesResponse.Issues[j].ID == issueActivities[i].Issue.ID {
 				issueActivities[i].Issue.Subject =
-					timeEntriesResponse.TimeEntries[j].Issue.Subject
+					issuesResponse.Issues[j].Subject
 				break
 			}
 		}

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -343,6 +343,13 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 	return proxy.Do(c, redmineURL)
 }
 
+// getIssuesHandler godoc
+// @Summary	Proxy for the "/issues.json" Redmine endpoint
+// @Accept	json
+// @Produce	json
+// @Failure	401	{string}	error "Unauthorized"
+// @Failure	500	{string}	error "Internal Server Error"
+// @Router /api/issues [get]
 func getIssuesHandler(c *fiber.Ctx) error {
 	if ok, err := prepareRedmineRequest(c); !ok {
 		return err

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -37,6 +37,11 @@ func prepareRedmineRequest(c *fiber.Ctx) (bool, error) {
 	return true, nil
 }
 
+type user struct {
+	UserId int    `json:"user_id"`
+	Login  string `json:"login"`
+}
+
 // loginHandler godoc
 // @Summary Log in a user
 // @Description Log in a user using the Redmine API
@@ -88,10 +93,7 @@ func loginHandler(c *fiber.Ctx) error {
 
 	log.Debugf("Logged in user %v", loginResponse)
 
-	return c.JSON(struct {
-		UserId int    `json:"user_id"`
-		Login  string `json:"login"`
-	}{
+	return c.JSON(user{
 		UserId: loginResponse.User.Id,
 		Login:  loginResponse.User.Login,
 	})

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -43,13 +43,15 @@ type user struct {
 }
 
 // loginHandler godoc
-// @Summary Log in a user
-// @Description Log in a user using the Redmine API
-// @Security BasicAuth
-// @Accept  json
-// @Produce  json
-// @Success 200 {object} LoginResponse
-// @Failure 401 {string} error "Unauthorized"
+// @Summary	Log in a user
+// @Description	Log in a user using the Redmine API
+// @Security	BasicAuth
+// @Accept	json
+// @Produce	json
+// @Success	200	{object}	user
+// @Failure	401	{string}	error "Unauthorized"
+// @Failure	422	{string}	error "Unprocessable Entity"
+// @Failure	500	{string}	error "Internal Server Error"
 // @Router /api/login [post]
 func loginHandler(c *fiber.Ctx) error {
 	session, err := store.Get(c)
@@ -100,12 +102,13 @@ func loginHandler(c *fiber.Ctx) error {
 }
 
 // logoutHandler godoc
-// @Summary Log out a user
-// @Description Log out a user by destroying the session
-// @Accept  json
-// @Produce  json
-// @Success 200 {string} error "OK"
-// @Failure 500 {string} error "Internal Server Error"
+// @Summary	Log out a user
+// @Description	Log out a user by destroying the session
+// @Accept	json
+// @Produce	json
+// @Success	204	{string}	error "No Content"
+// @Failure	401	{string}	error "Unauthorized"
+// @Failure	500	{string}	error "Internal Server Error"
 // @Router /api/logout [post]
 func logoutHandler(c *fiber.Ctx) error {
 	session, err := store.Get(c)
@@ -142,14 +145,13 @@ type issueActivity struct {
 }
 
 // recentIssuesHandler godoc
-// @Summary get issues that the user has spent time on
-// @Description get recent issues
-// @Param Cookie header string true "default"
-// @Accept  json
-// @Produce  json
-// @Success 200 {array} IssueActivityResponse
-// @Failure 401 {string} error "Unauthorized"
-// @Failure 500 {string} error "Internal Server Error"
+// @Summary	Get recent issues
+// @Description	Get recent issues that the user has spent time on
+// @Accept	json
+// @Produce	json
+// @Success	200	{array}	issueActivity
+// @Failure	401	{string} error "Unauthorized"
+// @Failure	500	{string} error "Internal Server Error"
 // @Router /api/recent_issues [get]
 func recentIssuesHandler(c *fiber.Ctx) error {
 	/* We want to return a list of pairs of issues and activities,
@@ -262,19 +264,11 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 }
 
 // getTimeEntriesHandler godoc
-// @Summary Proxy for the "/time_entries.json" Redmine endpoint
-// @Description get time entries
-// @Param Cookie header string true "default"
-// @Param from query string false "start date"
-// @Param to query string false "end date"
-// @Param spent_on string false "date"
-// @Param issue_id query int false "Redmine issue ID"
-// @Param activity_id query int false "Redmine activity ID"
-// @Accept  json
-// @Produce  json
-// @Success 200 {array} redmine.FetchedTimeEntry
-// @Failure 401 {string} error "Unauthorized"
-// @Failure 500 {string} error "Internal Server Error"
+// @Summary	Proxy for the "/time_entries.json" Redmine endpoint
+// @Accept	json
+// @Produce	json
+// @Failure	401	{string}	error "Unauthorized"
+// @Failure	500	{string}	error "Internal Server Error"
 // @Router /api/time_entries [get]
 func getTimeEntriesHandler(c *fiber.Ctx) error {
 	if ok, err := prepareRedmineRequest(c); !ok {
@@ -289,15 +283,12 @@ func getTimeEntriesHandler(c *fiber.Ctx) error {
 }
 
 // postTimeEntriesHandler godoc
-// @Summary report time spent on an issue
-// @Description report time spent on an issue
-// @Param time_entry body redmine.TimeEntry true "urdr_session=default"
-// @Param Cookie header string true "default"
-// @Accept  json
-// @Produce  json
-// @Success 200 {string} error "OK"
-// @Failure 401 {string} error "Unauthorized"
-// @Failure 500 {string} error "Internal Server Error"
+// @Summary	Create, update, or delete a time entry
+// @Accept	json
+// @Produce	json
+// @Success	200	{string}	error "OK"
+// @Failure	401	{string}	error "Unauthorized"
+// @Failure	500	{string}	error "Internal Server Error"
 // @Router /api/time_entries [post]
 func postTimeEntriesHandler(c *fiber.Ctx) error {
 	if ok, err := prepareRedmineRequest(c); !ok {

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -127,12 +127,12 @@ func logoutHandler(c *fiber.Ctx) error {
 }
 
 type issue struct {
-	ID      int    `json:"id"`
+	Id      int    `json:"id"`
 	Subject string `json:"subject"`
 }
 
 type activity struct {
-	ID   int    `json:"id"`
+	Id   int    `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -198,15 +198,15 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 			seenIssueActivities[issueActivity] = true
 			issueActivities = append(issueActivities, issueActivity)
 
-			if !seenIssueIds[issueActivity.Issue.ID] {
-				seenIssueIds[issueActivity.Issue.ID] = true
+			if !seenIssueIds[issueActivity.Issue.Id] {
+				seenIssueIds[issueActivity.Issue.Id] = true
 
 				// We append the issue IDs as strings
 				// to be able to conveniently create
 				// a comma-delimited list using
 				// strings.Join() later.
 				issueIds = append(issueIds,
-					fmt.Sprintf("%d", issueActivity.Issue.ID))
+					fmt.Sprintf("%d", issueActivity.Issue.Id))
 			}
 		}
 	}
@@ -241,7 +241,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 
 	for i := range issueActivities {
 		for j := range issuesResponse.Issues {
-			if issuesResponse.Issues[j].ID == issueActivities[i].Issue.ID {
+			if issuesResponse.Issues[j].Id == issueActivities[i].Issue.Id {
 				issueActivities[i].Issue.Subject =
 					issuesResponse.Issues[j].Subject
 				break

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -19,6 +19,31 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/issues": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Proxy for the \"/issues.json\" Redmine endpoint",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/login": {
             "post": {
                 "security": [

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -38,11 +38,23 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.LoginResponse"
+                            "$ref": "#/definitions/api.user"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -61,8 +73,14 @@ const docTemplate = `{
                 ],
                 "summary": "Log out a user",
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "string"
                         }
@@ -78,30 +96,21 @@ const docTemplate = `{
         },
         "/api/recent_issues": {
             "get": {
-                "description": "get recent issues",
+                "description": "Get recent issues that the user has spent time on",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "get recent issues",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
+                "summary": "Get recent issues",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/api.IssueActivityResponse"
+                                "$ref": "#/definitions/api.issueActivity"
                             }
                         }
                     },
@@ -120,91 +129,43 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/report": {
+        "/api/time_entries": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Proxy for the \"/time_entries.json\" Redmine endpoint",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
-                "description": "report time spent on issues",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "report time spent on issues",
-                "parameters": [
-                    {
-                        "description": "urdr_session=default",
-                        "name": "time_entry",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/redmine.TimeEntry"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
+                "summary": "Create, update, or delete a time entry",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/spent_time": {
-            "get": {
-                "description": "get time entries within start and end dates",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "get time entries within a given time period",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "start date",
-                        "name": "start_date",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "end date",
-                        "name": "end_date",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.SpentOnIssueActivityResponse"
-                            }
                         }
                     },
                     "401": {
@@ -224,46 +185,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "api.IssueActivityResponse": {
-            "type": "object",
-            "properties": {
-                "activity": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "issue": {
-                    "$ref": "#/definitions/redmine.Issue"
-                }
-            }
-        },
-        "api.LoginResponse": {
-            "type": "object",
-            "properties": {
-                "login": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "integer"
-                }
-            }
-        },
-        "api.SpentOnIssueActivityResponse": {
-            "type": "object",
-            "properties": {
-                "activity": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "hours": {
-                    "type": "number"
-                },
-                "issue": {
-                    "$ref": "#/definitions/redmine.Issue"
-                },
-                "spent_on": {
-                    "type": "string"
-                }
-            }
-        },
-        "redmine.IdName": {
+        "api.activity": {
             "type": "object",
             "properties": {
                 "id": {
@@ -274,90 +196,32 @@ const docTemplate = `{
                 }
             }
         },
-        "redmine.Issue": {
+        "api.issue": {
             "type": "object",
             "properties": {
-                "assigned_to": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "assigned_to_id": {
-                    "type": "integer"
-                },
-                "author": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "category": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "category_id": {
-                    "type": "integer"
-                },
-                "closed_on": {
-                    "type": "string"
-                },
-                "created_on": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "done_ratio": {
-                    "type": "number"
-                },
-                "due_date": {
-                    "type": "string"
-                },
-                "estimated_hours": {
-                    "type": "number"
-                },
                 "id": {
-                    "type": "integer"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "project": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "project_id": {
-                    "type": "integer"
-                },
-                "start_date": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "status_date": {
-                    "type": "string"
-                },
-                "status_id": {
                     "type": "integer"
                 },
                 "subject": {
                     "type": "string"
-                },
-                "updated_on": {
-                    "type": "string"
                 }
             }
         },
-        "redmine.TimeEntry": {
+        "api.issueActivity": {
             "type": "object",
             "properties": {
-                "activity_id": {
-                    "type": "integer"
+                "activity": {
+                    "$ref": "#/definitions/api.activity"
                 },
-                "comments": {
-                    "type": "string"
-                },
-                "hours": {
-                    "type": "integer"
-                },
-                "issue_id": {
-                    "type": "integer"
-                },
-                "spent_on": {
+                "issue": {
+                    "$ref": "#/definitions/api.issue"
+                }
+            }
+        },
+        "api.user": {
+            "type": "object",
+            "properties": {
+                "login": {
                     "type": "string"
                 },
                 "user_id": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -31,11 +31,23 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.LoginResponse"
+                            "$ref": "#/definitions/api.user"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -54,8 +66,14 @@
                 ],
                 "summary": "Log out a user",
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "string"
                         }
@@ -71,30 +89,21 @@
         },
         "/api/recent_issues": {
             "get": {
-                "description": "get recent issues",
+                "description": "Get recent issues that the user has spent time on",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "get recent issues",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
+                "summary": "Get recent issues",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/api.IssueActivityResponse"
+                                "$ref": "#/definitions/api.issueActivity"
                             }
                         }
                     },
@@ -113,91 +122,43 @@
                 }
             }
         },
-        "/api/report": {
+        "/api/time_entries": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Proxy for the \"/time_entries.json\" Redmine endpoint",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
-                "description": "report time spent on issues",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "report time spent on issues",
-                "parameters": [
-                    {
-                        "description": "urdr_session=default",
-                        "name": "time_entry",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/redmine.TimeEntry"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
+                "summary": "Create, update, or delete a time entry",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/spent_time": {
-            "get": {
-                "description": "get time entries within start and end dates",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "get time entries within a given time period",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "default",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "start date",
-                        "name": "start_date",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "end date",
-                        "name": "end_date",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.SpentOnIssueActivityResponse"
-                            }
                         }
                     },
                     "401": {
@@ -217,46 +178,7 @@
         }
     },
     "definitions": {
-        "api.IssueActivityResponse": {
-            "type": "object",
-            "properties": {
-                "activity": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "issue": {
-                    "$ref": "#/definitions/redmine.Issue"
-                }
-            }
-        },
-        "api.LoginResponse": {
-            "type": "object",
-            "properties": {
-                "login": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "integer"
-                }
-            }
-        },
-        "api.SpentOnIssueActivityResponse": {
-            "type": "object",
-            "properties": {
-                "activity": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "hours": {
-                    "type": "number"
-                },
-                "issue": {
-                    "$ref": "#/definitions/redmine.Issue"
-                },
-                "spent_on": {
-                    "type": "string"
-                }
-            }
-        },
-        "redmine.IdName": {
+        "api.activity": {
             "type": "object",
             "properties": {
                 "id": {
@@ -267,90 +189,32 @@
                 }
             }
         },
-        "redmine.Issue": {
+        "api.issue": {
             "type": "object",
             "properties": {
-                "assigned_to": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "assigned_to_id": {
-                    "type": "integer"
-                },
-                "author": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "category": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "category_id": {
-                    "type": "integer"
-                },
-                "closed_on": {
-                    "type": "string"
-                },
-                "created_on": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "done_ratio": {
-                    "type": "number"
-                },
-                "due_date": {
-                    "type": "string"
-                },
-                "estimated_hours": {
-                    "type": "number"
-                },
                 "id": {
-                    "type": "integer"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "project": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "project_id": {
-                    "type": "integer"
-                },
-                "start_date": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/redmine.IdName"
-                },
-                "status_date": {
-                    "type": "string"
-                },
-                "status_id": {
                     "type": "integer"
                 },
                 "subject": {
                     "type": "string"
-                },
-                "updated_on": {
-                    "type": "string"
                 }
             }
         },
-        "redmine.TimeEntry": {
+        "api.issueActivity": {
             "type": "object",
             "properties": {
-                "activity_id": {
-                    "type": "integer"
+                "activity": {
+                    "$ref": "#/definitions/api.activity"
                 },
-                "comments": {
-                    "type": "string"
-                },
-                "hours": {
-                    "type": "integer"
-                },
-                "issue_id": {
-                    "type": "integer"
-                },
-                "spent_on": {
+                "issue": {
+                    "$ref": "#/definitions/api.issue"
+                }
+            }
+        },
+        "api.user": {
+            "type": "object",
+            "properties": {
+                "login": {
                     "type": "string"
                 },
                 "user_id": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12,6 +12,31 @@
     "host": "localhost:8080",
     "basePath": "/",
     "paths": {
+        "/api/issues": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Proxy for the \"/issues.json\" Redmine endpoint",
+                "responses": {
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/login": {
             "post": {
                 "security": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,93 +1,29 @@
 basePath: /
 definitions:
-  api.IssueActivityResponse:
-    properties:
-      activity:
-        $ref: '#/definitions/redmine.IdName'
-      issue:
-        $ref: '#/definitions/redmine.Issue'
-    type: object
-  api.LoginResponse:
-    properties:
-      login:
-        type: string
-      user_id:
-        type: integer
-    type: object
-  api.SpentOnIssueActivityResponse:
-    properties:
-      activity:
-        $ref: '#/definitions/redmine.IdName'
-      hours:
-        type: number
-      issue:
-        $ref: '#/definitions/redmine.Issue'
-      spent_on:
-        type: string
-    type: object
-  redmine.IdName:
+  api.activity:
     properties:
       id:
         type: integer
       name:
         type: string
     type: object
-  redmine.Issue:
+  api.issue:
     properties:
-      assigned_to:
-        $ref: '#/definitions/redmine.IdName'
-      assigned_to_id:
-        type: integer
-      author:
-        $ref: '#/definitions/redmine.IdName'
-      category:
-        $ref: '#/definitions/redmine.IdName'
-      category_id:
-        type: integer
-      closed_on:
-        type: string
-      created_on:
-        type: string
-      description:
-        type: string
-      done_ratio:
-        type: number
-      due_date:
-        type: string
-      estimated_hours:
-        type: number
       id:
-        type: integer
-      notes:
-        type: string
-      project:
-        $ref: '#/definitions/redmine.IdName'
-      project_id:
-        type: integer
-      start_date:
-        type: string
-      status:
-        $ref: '#/definitions/redmine.IdName'
-      status_date:
-        type: string
-      status_id:
         type: integer
       subject:
         type: string
-      updated_on:
-        type: string
     type: object
-  redmine.TimeEntry:
+  api.issueActivity:
     properties:
-      activity_id:
-        type: integer
-      comments:
-        type: string
-      hours:
-        type: integer
-      issue_id:
-        type: integer
-      spent_on:
+      activity:
+        $ref: '#/definitions/api.activity'
+      issue:
+        $ref: '#/definitions/api.issue'
+    type: object
+  api.user:
+    properties:
+      login:
         type: string
       user_id:
         type: integer
@@ -112,9 +48,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.LoginResponse'
+            $ref: '#/definitions/api.user'
         "401":
           description: Unauthorized
+          schema:
+            type: string
+        "422":
+          description: Unprocessable Entity
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
           schema:
             type: string
       security:
@@ -128,8 +72,12 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "204":
+          description: No Content
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
           schema:
             type: string
         "500":
@@ -141,13 +89,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: get recent issues
-      parameters:
-      - description: default
-        in: header
-        name: Cookie
-        required: true
-        type: string
+      description: Get recent issues that the user has spent time on
       produces:
       - application/json
       responses:
@@ -155,7 +97,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.IssueActivityResponse'
+              $ref: '#/definitions/api.issueActivity'
             type: array
         "401":
           description: Unauthorized
@@ -165,66 +107,14 @@ paths:
           description: Internal Server Error
           schema:
             type: string
-      summary: get recent issues
-  /api/report:
-    post:
-      consumes:
-      - application/json
-      description: report time spent on issues
-      parameters:
-      - description: urdr_session=default
-        in: body
-        name: time_entry
-        required: true
-        schema:
-          $ref: '#/definitions/redmine.TimeEntry'
-      - description: default
-        in: header
-        name: Cookie
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            type: string
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-      summary: report time spent on issues
-  /api/spent_time:
+      summary: Get recent issues
+  /api/time_entries:
     get:
       consumes:
       - application/json
-      description: get time entries within start and end dates
-      parameters:
-      - description: default
-        in: header
-        name: Cookie
-        required: true
-        type: string
-      - description: start date
-        in: query
-        name: start_date
-        required: true
-        type: string
-      - description: end date
-        in: query
-        name: end_date
-        required: true
-        type: string
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/api.SpentOnIssueActivityResponse'
-            type: array
         "401":
           description: Unauthorized
           schema:
@@ -233,7 +123,26 @@ paths:
           description: Internal Server Error
           schema:
             type: string
-      summary: get time entries within a given time period
+      summary: Proxy for the "/time_entries.json" Redmine endpoint
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Create, update, or delete a time entry
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -37,6 +37,22 @@ info:
   title: Urdr API
   version: "1.0"
 paths:
+  /api/issues:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Proxy for the "/issues.json" Redmine endpoint
   /api/login:
     post:
       consumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,4 +13,8 @@ server {
     location /api/ {
         proxy_pass http://urdr:8080/api/;
     }
+
+    location /swagger/ {
+        proxy_pass http://urdr:8080/swagger/;
+    }
 }


### PR DESCRIPTION
This PR aims to update the documentation of the endpoints, which went largely untouched by the recent refactoring.

This includes replacing some unnamed structs with named structs and generally re-jigging some of the code. Some endpoints mostly lack documentation of the returned structure format. This is since it's Redmine that creates the data, not our backend. The endpoints that act as proxies for Redmine take whatever parameters Redmine's API specify.

Closes #187 
