### PR TITLE
Dev/issues endpoint

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -51,9 +51,11 @@ func Setup() *fiber.App {
 
 	app.Post("/api/time_entries", postTimeEntriesHandler)
 
+	app.Get("/api/issues", getIssuesHandler)
+
 	// 404 Handler
 	app.Use(func(c *fiber.Ctx) error {
-		return c.SendStatus(404) // => 404 "Not Found"
+		return c.SendStatus(fiber.StatusNotFound) // => 404 "Not Found"
 	})
 
 	// Return the configured app

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -374,3 +374,14 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 
 	return proxy.Do(c, redmineURL)
 }
+
+func getIssuesHandler(c *fiber.Ctx) error {
+	if ok, err := prepareRedmineRequest(c); !ok {
+		return err
+	}
+
+	redmineURL := fmt.Sprintf("%s/issues.json?%s",
+		config.Config.Redmine.URL, c.Request().URI().QueryString())
+
+	return proxy.Do(c, redmineURL)
+}


### PR DESCRIPTION
This PR adds a handler, `getIssuesHandler()`, and an endpoint,`/api/issues`, for GET requests.

The handler proxies the requests to the Redmine `/issues.json` endpoint.  This means you may get the data for an issue by passing the parameter `issue_id=ID`, for some `ID`.  You may also ask for multiple issues by passing a comma-delimited list of IDs to this single query parameter.

Closes #186 