### PR TITLE
Dev/database refactor

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"urdr-api/api"
 	"urdr-api/internal/config"
-	"urdr-api/internal/database"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -19,10 +18,6 @@ func init() {
 
 	if err := config.Setup(); err != nil {
 		log.Fatalf("config.LoadConfig() failed: %v", err)
-	}
-
-	if err := database.Setup(); err != nil {
-		log.Fatalf("db.Setup() failed: %v", err)
 	}
 }
 

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -16,10 +16,10 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// A database is represented by a private structure containing a handle
-// to the underlying database connection object.
+// A database contains a private method, handle(), that returns a handle
+// to the underlying database connection handle.
 type database struct {
-	Handle func() *sql.DB
+	handle func() *sql.DB
 }
 
 // New() connects to the database, returns a database object.
@@ -35,5 +35,5 @@ func New() (*database, error) {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
 	}
 
-	return &database{Handle: func() *sql.DB { return handle }}, nil
+	return &database{handle: func() *sql.DB { return handle }}, nil
 }

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -4,8 +4,6 @@
 package database
 
 import (
-	"urdr-api/internal/config"
-
 	"database/sql"
 	"fmt"
 
@@ -23,10 +21,10 @@ type database struct {
 }
 
 // New() connects to the database, returns a database object.
-func New() (*database, error) {
+func New(databasePath string) (*database, error) {
 	handle, err := sql.Open("sqlite3",
 		fmt.Sprintf("%s?_auto_vacuum=FULL&_foreign_keys=true",
-			config.Config.Database.Path))
+			databasePath))
 	if err != nil {
 		return nil, fmt.Errorf("sql.Open() failed: %w", err)
 	}

--- a/backend/internal/database/database_test.go
+++ b/backend/internal/database/database_test.go
@@ -1,4 +1,4 @@
-package database
+package database_test
 
 import (
 	"log"
@@ -18,11 +18,6 @@ func TestMain(m *testing.M) {
 	err = config.Setup()
 	if err != nil {
 		log.Fatalf("config.Setup() failed: %v", err)
-	}
-
-	err = Setup()
-	if err != nil {
-		log.Fatalf("database.Setup() failed: %v", err)
 	}
 
 	os.Exit(m.Run())

--- a/backend/internal/database/favorite.go
+++ b/backend/internal/database/favorite.go
@@ -39,17 +39,15 @@ func (db *database) GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 	for rows.Next() {
 		var favorite Favorite
 
-		err = rows.Scan(&favorite.RedmineIssueId,
+		if err := rows.Scan(&favorite.RedmineIssueId,
 			&favorite.RedmineActivityId,
-			&favorite.Name)
-		if err != nil {
+			&favorite.Name); err != nil {
 			return nil, fmt.Errorf("sql.Scan() failed: %w", err)
 		}
 
 		favorites = append(favorites, favorite)
 	}
-	err = rows.Err()
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("sql.Next() failed: %w", err)
 	}
 
@@ -85,8 +83,7 @@ func (db *database) SetAllUserFavorites(redmineUserId int, favorites []Favorite)
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(redmineUserId)
-	if err != nil {
+	if _, err := stmt.Exec(redmineUserId); err != nil {
 		return fmt.Errorf("sql.Exec() failed: %w", err)
 	}
 
@@ -106,19 +103,17 @@ func (db *database) SetAllUserFavorites(redmineUserId int, favorites []Favorite)
 	defer stmt.Close()
 
 	for priority, favorite := range favorites {
-		_, err = stmt.Exec(redmineUserId,
+		if _, err := stmt.Exec(redmineUserId,
 			favorite.RedmineIssueId,
 			favorite.RedmineActivityId,
 			favorite.Name,
-			priority)
-		if err != nil {
+			priority); err != nil {
 			return fmt.Errorf("sql.Exec() failed: %w", err)
 		}
 	}
 
 	// The deferred tx.Rollback() will be a no-op after this.
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("sql.Tx.Commit() failed: %w", err)
 	}
 
@@ -138,8 +133,7 @@ func (db *database) DeleteAllUserFavorites(redmineUserId int) error {
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(redmineUserId)
-	if err != nil {
+	if _, err := stmt.Exec(redmineUserId); err != nil {
 		return fmt.Errorf("sql.Exec() failed: %w", err)
 	}
 

--- a/backend/internal/database/favorite.go
+++ b/backend/internal/database/favorite.go
@@ -22,7 +22,7 @@ func (db *database) GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 		WHERE	redmine_user_id = ?
 		ORDER BY	priority`
 
-	stmt, err := db.Handle().Prepare(selectStmt)
+	stmt, err := db.handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -59,7 +59,7 @@ func (db *database) GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 // SetAllUserFavorites() replaces all stored favorites for the given
 // user by the ones provided in the list to this function.
 func (db *database) SetAllUserFavorites(redmineUserId int, favorites []Favorite) error {
-	tx, err := db.Handle().Begin()
+	tx, err := db.handle().Begin()
 	if err != nil {
 		return fmt.Errorf("sql.Begin() failed: %w", err)
 	}
@@ -132,7 +132,7 @@ func (db *database) DeleteAllUserFavorites(redmineUserId int) error {
 		DELETE FROM favorite
 		WHERE	redmine_user_id = ?`
 
-	stmt, err := db.Handle().Prepare(deleteStmt)
+	stmt, err := db.handle().Prepare(deleteStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}

--- a/backend/internal/database/favorite.go
+++ b/backend/internal/database/favorite.go
@@ -13,7 +13,7 @@ type Favorite struct {
 
 // GetAllUserFavorites() returns a list of favorites for a particular
 // user.
-func GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
+func (db *database) GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 	selectStmt := `
 		SELECT	redmine_issue_id,
 			redmine_activity_id,
@@ -22,7 +22,7 @@ func GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 		WHERE	redmine_user_id = ?
 		ORDER BY	priority`
 
-	stmt, err := db.Prepare(selectStmt)
+	stmt, err := db.Handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -58,8 +58,8 @@ func GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 
 // SetAllUserFavorites() replaces all stored favorites for the given
 // user by the ones provided in the list to this function.
-func SetAllUserFavorites(redmineUserId int, favorites []Favorite) error {
-	tx, err := db.Begin()
+func (db *database) SetAllUserFavorites(redmineUserId int, favorites []Favorite) error {
+	tx, err := db.Handle().Begin()
 	if err != nil {
 		return fmt.Errorf("sql.Begin() failed: %w", err)
 	}
@@ -127,12 +127,12 @@ func SetAllUserFavorites(redmineUserId int, favorites []Favorite) error {
 
 // DeleteAllUserFavorites() removes all stored favorites for the given
 // user.
-func DeleteAllUserFavorites(redmineUserId int) error {
+func (db *database) DeleteAllUserFavorites(redmineUserId int) error {
 	deleteStmt := `
 		DELETE FROM favorite
 		WHERE	redmine_user_id = ?`
 
-	stmt, err := db.Prepare(deleteStmt)
+	stmt, err := db.Handle().Prepare(deleteStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}

--- a/backend/internal/database/favorite_test.go
+++ b/backend/internal/database/favorite_test.go
@@ -1,11 +1,12 @@
-package database
+package database_test
 
 import (
 	"testing"
+	"urdr-api/internal/database"
 )
 
 func TestFavorites(t *testing.T) {
-	storeFaves := []Favorite{
+	storeFaves := []database.Favorite{
 		{
 			RedmineIssueId:    1,
 			RedmineActivityId: 1,
@@ -15,17 +16,22 @@ func TestFavorites(t *testing.T) {
 			RedmineActivityId: 1,
 			Name:              "Test 2"}}
 
-	err := DeleteAllUserFavorites(1)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	err = db.DeleteAllUserFavorites(1)
 	if err != nil {
 		t.Fatalf("DeleteAllUserFavorites() failed: %v", err)
 	}
 
-	err = SetAllUserFavorites(1, storeFaves)
+	err = db.SetAllUserFavorites(1, storeFaves)
 	if err != nil {
 		t.Fatalf("SetAllUserFavorites() failed: %v", err)
 	}
 
-	fetchFaves, err := GetAllUserFavorites(1)
+	fetchFaves, err := db.GetAllUserFavorites(1)
 	if err != nil {
 		t.Fatalf("GetAllUserFavorites() failed: %v", err)
 	}
@@ -40,12 +46,12 @@ func TestFavorites(t *testing.T) {
 		}
 	}
 
-	err = DeleteAllUserFavorites(1)
+	err = db.DeleteAllUserFavorites(1)
 	if err != nil {
 		t.Fatalf("DeleteAllUserFavorites() failed: %v", err)
 	}
 
-	fetchFaves, err = GetAllUserFavorites(1)
+	fetchFaves, err = db.GetAllUserFavorites(1)
 	if err != nil {
 		t.Fatalf("GetAllUserFavorites() failed: %v", err)
 	}

--- a/backend/internal/database/favorite_test.go
+++ b/backend/internal/database/favorite_test.go
@@ -2,6 +2,7 @@ package database_test
 
 import (
 	"testing"
+	"urdr-api/internal/config"
 	"urdr-api/internal/database"
 )
 
@@ -16,7 +17,7 @@ func TestFavorites(t *testing.T) {
 			RedmineActivityId: 1,
 			Name:              "Test 2"}}
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -19,8 +19,7 @@ type Setting struct {
 // (setting ID, name and value), given the setting's name.  It returns
 // an error for illegal settings.
 func (db *database) getSetting(settingName string) (*Setting, error) {
-	err := db.handle().Ping()
-	if err != nil {
+	if err := db.handle().Ping(); err != nil {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
 	}
 
@@ -46,15 +45,13 @@ func (db *database) getSetting(settingName string) (*Setting, error) {
 	var settingValue sql.NullString
 
 	for rows.Next() {
-		err = rows.Scan(&settingId, &settingValue)
-		if err != nil {
+		if err := rows.Scan(&settingId, &settingValue); err != nil {
 			return nil, fmt.Errorf("sql.Scan() failed: %w", err)
 		}
 
 		isValidSetting = true
 	}
-	err = rows.Err()
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("sql.Next() failed: %w", err)
 	}
 
@@ -107,15 +104,13 @@ func (db *database) GetUserSetting(redmineUserId int, settingName string) (*Sett
 	var userSettingValue sql.NullString
 
 	for rows.Next() {
-		err = rows.Scan(&userSettingValue)
-		if err != nil {
+		if err := rows.Scan(&userSettingValue); err != nil {
 			return nil, fmt.Errorf("sql.Scan() failed: %w", err)
 		}
 
 		userSettingFound = true
 	}
-	err = rows.Err()
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("sql.Next() failed: %w", err)
 	}
 
@@ -146,8 +141,7 @@ func (db *database) SetUserSetting(redmineUserId int, settingName string, settin
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(redmineUserId, setting.id, settingValue)
-	if err != nil {
+	if _, err := stmt.Exec(redmineUserId, setting.id, settingValue); err != nil {
 		return fmt.Errorf("sql.Exec() failed: %w", err)
 	}
 
@@ -173,8 +167,7 @@ func (db *database) DeleteUserSetting(redmineUserId int, settingName string) err
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(redmineUserId, setting.id)
-	if err != nil {
+	if _, err := stmt.Exec(redmineUserId, setting.id); err != nil {
 		return fmt.Errorf("sql.Exec() failed: %w", err)
 	}
 

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -18,8 +18,8 @@ type Setting struct {
 // getSetting() is an internal function that returns the setting struct
 // (setting ID, name and value), given the setting's name.  It returns
 // an error for illegal settings.
-func getSetting(settingName string) (*Setting, error) {
-	err := db.Ping()
+func (db *database) getSetting(settingName string) (*Setting, error) {
+	err := db.Handle().Ping()
 	if err != nil {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
 	}
@@ -29,7 +29,7 @@ func getSetting(settingName string) (*Setting, error) {
 		FROM	setting
 		WHERE	name = ?`
 
-	stmt, err := db.Prepare(selectStmt)
+	stmt, err := db.Handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -79,8 +79,8 @@ func getSetting(settingName string) (*Setting, error) {
 // user-specific value for a particular setting.  If there is no
 // user-specific value stored for the given user, then the default value
 // is returned, if there is one.
-func GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
-	setting, err := getSetting(settingName)
+func (db *database) GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
+	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return nil, fmt.Errorf("getSetting() failed: %w", err)
 	}
@@ -91,7 +91,7 @@ func GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
 		WHERE	redmine_user_id = ?
 		AND	setting_id = ?`
 
-	stmt, err := db.Prepare(selectStmt)
+	stmt, err := db.Handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -130,8 +130,8 @@ func GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
 // SetUserSetting() assigns the user-specific value for a particular
 // setting.  If there is already a user-specific value stored for the
 // given setting, the new value replaces the old value.
-func SetUserSetting(redmineUserId int, settingName string, settingValue string) error {
-	setting, err := getSetting(settingName)
+func (db *database) SetUserSetting(redmineUserId int, settingName string, settingValue string) error {
+	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return fmt.Errorf("getSetting() failed: %w", err)
 	}
@@ -140,7 +140,7 @@ func SetUserSetting(redmineUserId int, settingName string, settingValue string) 
 		INSERT INTO user_setting (redmine_user_id, setting_id, value)
 		VALUES (?, ?, ?)`
 
-	stmt, err := db.Prepare(insertStmt)
+	stmt, err := db.Handle().Prepare(insertStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -156,8 +156,8 @@ func SetUserSetting(redmineUserId int, settingName string, settingValue string) 
 
 // DeleteUserSetting() removes the user-specific value for a particular
 // setting.
-func DeleteUserSetting(redmineUserId int, settingName string) error {
-	setting, err := getSetting(settingName)
+func (db *database) DeleteUserSetting(redmineUserId int, settingName string) error {
+	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return fmt.Errorf("getSetting() failed: %w", err)
 	}
@@ -167,7 +167,7 @@ func DeleteUserSetting(redmineUserId int, settingName string) error {
 		WHERE	redmine_user_id = ?
 		AND	setting_id = ?`
 
-	stmt, err := db.Prepare(deleteStmt)
+	stmt, err := db.Handle().Prepare(deleteStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -19,7 +19,7 @@ type Setting struct {
 // (setting ID, name and value), given the setting's name.  It returns
 // an error for illegal settings.
 func (db *database) getSetting(settingName string) (*Setting, error) {
-	err := db.Handle().Ping()
+	err := db.handle().Ping()
 	if err != nil {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
 	}
@@ -29,7 +29,7 @@ func (db *database) getSetting(settingName string) (*Setting, error) {
 		FROM	setting
 		WHERE	name = ?`
 
-	stmt, err := db.Handle().Prepare(selectStmt)
+	stmt, err := db.handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -91,7 +91,7 @@ func (db *database) GetUserSetting(redmineUserId int, settingName string) (*Sett
 		WHERE	redmine_user_id = ?
 		AND	setting_id = ?`
 
-	stmt, err := db.Handle().Prepare(selectStmt)
+	stmt, err := db.handle().Prepare(selectStmt)
 	if err != nil {
 		return nil, fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -140,7 +140,7 @@ func (db *database) SetUserSetting(redmineUserId int, settingName string, settin
 		INSERT INTO user_setting (redmine_user_id, setting_id, value)
 		VALUES (?, ?, ?)`
 
-	stmt, err := db.Handle().Prepare(insertStmt)
+	stmt, err := db.handle().Prepare(insertStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}
@@ -167,7 +167,7 @@ func (db *database) DeleteUserSetting(redmineUserId int, settingName string) err
 		WHERE	redmine_user_id = ?
 		AND	setting_id = ?`
 
-	stmt, err := db.Handle().Prepare(deleteStmt)
+	stmt, err := db.handle().Prepare(deleteStmt)
 	if err != nil {
 		return fmt.Errorf("sql.Prepare() failed: %w", err)
 	}

--- a/backend/internal/database/setting_test.go
+++ b/backend/internal/database/setting_test.go
@@ -1,16 +1,22 @@
-package database
+package database_test
 
 import (
 	"fmt"
 	"regexp"
 	"testing"
+	"urdr-api/internal/database"
 )
 
 func TestGetIllegalSetting(t *testing.T) {
 	settingName := "tuba"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	_, err := GetUserSetting(1, settingName)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	_, err = db.GetUserSetting(1, settingName)
 	if err == nil {
 		t.Fatal("GetUserSetting() returned no error")
 	}
@@ -24,7 +30,12 @@ func TestSetIllegalSetting(t *testing.T) {
 	settingValue := "bantu"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	err := SetUserSetting(1, settingName, settingValue)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	err = db.SetUserSetting(1, settingName, settingValue)
 	if err == nil {
 		t.Fatal("SetUserSetting() returned no error")
 	}
@@ -37,7 +48,12 @@ func TestDeleteIllegalSetting(t *testing.T) {
 	settingName := "tuba"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	err := DeleteUserSetting(1, settingName)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	err = db.DeleteUserSetting(1, settingName)
 	if err == nil {
 		t.Fatal("DeleteUserSetting() returned no error")
 	}
@@ -50,7 +66,12 @@ func TestGetDefaultSetting(t *testing.T) {
 	settingName := "tab"
 	want := "horizontal"
 
-	setting, err := GetUserSetting(1, settingName)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	setting, err := db.GetUserSetting(1, settingName)
 	if err != nil {
 		t.Fatalf("GetUserSetting() failed: %v", err)
 	}
@@ -66,12 +87,17 @@ func TestSetting(t *testing.T) {
 	want1 := settingValue
 	want2 := "horizontal"
 
-	err := SetUserSetting(1, settingName, settingValue)
+	db, err := database.New()
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	err = db.SetUserSetting(1, settingName, settingValue)
 	if err != nil {
 		t.Fatalf("SetUserSetting() failed: %v", err)
 	}
 
-	setting, err := GetUserSetting(1, settingName)
+	setting, err := db.GetUserSetting(1, settingName)
 	if err != nil {
 		t.Fatalf("GetUserSetting() failed: %v", err)
 	}
@@ -80,12 +106,12 @@ func TestSetting(t *testing.T) {
 			setting.Value, want1)
 	}
 
-	err = DeleteUserSetting(1, settingName)
+	err = db.DeleteUserSetting(1, settingName)
 	if err != nil {
 		t.Fatalf("DeleteUserSetting() failed: %v", err)
 	}
 
-	setting, err = GetUserSetting(1, settingName)
+	setting, err = db.GetUserSetting(1, settingName)
 	if err != nil {
 		t.Fatalf("GetUserSetting() failed: %v", err)
 	}

--- a/backend/internal/database/setting_test.go
+++ b/backend/internal/database/setting_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"urdr-api/internal/config"
 	"urdr-api/internal/database"
 )
 
@@ -11,7 +12,7 @@ func TestGetIllegalSetting(t *testing.T) {
 	settingName := "tuba"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}
@@ -30,7 +31,7 @@ func TestSetIllegalSetting(t *testing.T) {
 	settingValue := "bantu"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}
@@ -48,7 +49,7 @@ func TestDeleteIllegalSetting(t *testing.T) {
 	settingName := "tuba"
 	want := regexp.MustCompilePOSIX("illegal setting name: " + settingName + "$")
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}
@@ -66,7 +67,7 @@ func TestGetDefaultSetting(t *testing.T) {
 	settingName := "tab"
 	want := "horizontal"
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}
@@ -87,7 +88,7 @@ func TestSetting(t *testing.T) {
 	want1 := settingValue
 	want2 := "horizontal"
 
-	db, err := database.New()
+	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		t.Fatalf("database.New() returned unexpected error %q", err)
 	}


### PR DESCRIPTION
This PR refactors the API used by the backend to talk to the local SQLite3 database.  The main gain from this PR is that the database package now does not store the database handle as a package-global variable.  Instead, a `New()` constructor replaces the `Setup()` function and returns a struct that can be used to call the various database-related methods.  The struct contains a private handle used by the database methods, but that is otherwise unexposed.

We also decouple the `database` package from the `config` package by passing the pathname of the database file to the `New()` constructor.