### PR TITLE
Dev/favorites endpoint

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -57,6 +57,8 @@ func Setup() *fiber.App {
 
 	app.Get("/api/favorites", getFavoritesHandler)
 
+	app.Post("/api/favorites", postFavoritesHandler)
+
 	// 404 Handler
 	app.Use(func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusNotFound) // => 404 "Not Found"

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -55,6 +55,8 @@ func Setup() *fiber.App {
 
 	app.Get("/api/activities", getActivitiesHandler)
 
+	app.Get("/api/favorites", getFavoritesHandler)
+
 	// 404 Handler
 	app.Use(func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusNotFound) // => 404 "Not Found"

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -415,5 +415,27 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
-	return c.JSON(favorites)
+	var issueActivities []issueActivity
+
+	for i := range favorites {
+		issueActivity := issueActivity{
+			Issue: issue{
+				Id:      favorites[i].RedmineIssueId,
+				Subject: "",
+			},
+			Activity: activity{
+				Id:   favorites[i].RedmineActivityId,
+				Name: "",
+			},
+			CustomName: favorites[i].Name,
+		}
+
+		issueActivities = append(issueActivities, issueActivity)
+	}
+
+	if ok, err := fetchIssueSubjects(c, issueActivities); !ok {
+		return err
+	}
+
+	return c.JSON(issueActivities)
 }

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -406,7 +406,7 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 
 	userId := session.Get("user_id")
 	if userId == nil {
-		log.Error("Failed to get vaid user ID from session")
+		log.Error("Failed to get valid user ID from session")
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
@@ -498,7 +498,7 @@ func postFavoritesHandler(c *fiber.Ctx) error {
 	// The favorites are stored with the user's ID.
 	userId := session.Get("user_id")
 	if userId == nil {
-		log.Error("Failed to get vaid user ID from session")
+		log.Error("Failed to get valid user ID from session")
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -449,8 +449,10 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 	// activity names.
 	c.Response().Reset()
 	if err := getActivitiesHandler(c); err != nil {
+		// There was some error in the handler.
 		return err
 	} else if c.Response().StatusCode() != fiber.StatusOK {
+		// There was some error sent to us from Redmine.
 		return nil
 	}
 

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -197,8 +197,9 @@ type activity struct {
 }
 
 type issueActivity struct {
-	Issue    issue    `json:"issue"`
-	Activity activity `json:"activity"`
+	Issue      issue    `json:"issue"`
+	Activity   activity `json:"activity"`
+	CustomName string   `json:"custom_name"`
 }
 
 // recentIssuesHandler godoc

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -49,8 +49,8 @@ func fetchIssueSubjects(c *fiber.Ctx, issueActivities []issueActivity) (bool, er
 	seenIssueIds := make(map[int]bool)
 	var issueIds []string
 
-	for i := range issueActivities {
-		issueId := issueActivities[i].Issue.Id
+	for _, issueActivity := range issueActivities {
+		issueId := issueActivity.Issue.Id
 		if !seenIssueIds[issueId] {
 			seenIssueIds[issueId] = true
 			issueIds = append(issueIds, fmt.Sprintf("%d", issueId))
@@ -85,10 +85,9 @@ func fetchIssueSubjects(c *fiber.Ctx, issueActivities []issueActivity) (bool, er
 	// subject to each issue from the issuesResponse structure.
 
 	for i := range issueActivities {
-		for j := range issuesResponse.Issues {
-			if issuesResponse.Issues[j].Id == issueActivities[i].Issue.Id {
-				issueActivities[i].Issue.Subject =
-					issuesResponse.Issues[j].Subject
+		for _, issue := range issuesResponse.Issues {
+			if issue.Id == issueActivities[i].Issue.Id {
+				issueActivities[i].Issue.Subject = issue.Subject
 				break
 			}
 		}
@@ -248,9 +247,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 	seenIssueActivities := make(map[issueActivity]bool)
 	var issueActivities []issueActivity
 
-	for i := range timeEntriesResponse.TimeEntries {
-		issueActivity := timeEntriesResponse.TimeEntries[i]
-
+	for _, issueActivity := range timeEntriesResponse.TimeEntries {
 		if !seenIssueActivities[issueActivity] {
 			seenIssueActivities[issueActivity] = true
 			issueActivities = append(issueActivities, issueActivity)
@@ -417,17 +414,17 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 
 	var issueActivities []issueActivity
 
-	for i := range favorites {
+	for _, favorite := range favorites {
 		issueActivity := issueActivity{
 			Issue: issue{
-				Id:      favorites[i].RedmineIssueId,
+				Id:      favorite.RedmineIssueId,
 				Subject: "",
 			},
 			Activity: activity{
-				Id:   favorites[i].RedmineActivityId,
+				Id:   favorite.RedmineActivityId,
 				Name: "",
 			},
-			CustomName: favorites[i].Name,
+			CustomName: favorite.Name,
 		}
 
 		issueActivities = append(issueActivities, issueActivity)

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -254,6 +254,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 		}
 	}
 
+	// Populate the issue subjects.
 	if ok, err := fetchIssueSubjects(c, issueActivities); !ok {
 		return err
 	}
@@ -387,6 +388,15 @@ func getActivitiesHandler(c *fiber.Ctx) error {
 	return proxy.Do(c, redmineURL)
 }
 
+// getFavoritesHandler() godoc
+// @Summary	Get favorites
+// @Description	Get the favorites for the current user
+// @Accept	json
+// @Produce	json
+// @Success	200	{array}	issueActivity
+// @Failure	401	{string} error "Unauthorized"
+// @Failure	500	{string} error "Internal Server Error"
+// @Router /api/favorites [get]
 func getFavoritesHandler(c *fiber.Ctx) error {
 	session, err := store.Get(c)
 	if err != nil {
@@ -468,14 +478,17 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 	return c.JSON(issueActivities)
 }
 
+// postFavoritesHandler() godoc
+// @Summary	Store favorites
+// @Description	Stores the favorites for the current user
+// @Accept	json
+// @Produce	json
+// @Success	204	{string} error "No Content"
+// @Failure	401	{string} error "Unauthorized"
+// @Failure	422	{string} error "Unprocessable Entity"
+// @Failure	500	{string} error "Internal Server Error"
+// @Router /api/favorites [post]
 func postFavoritesHandler(c *fiber.Ctx) error {
-	// Parse the favoites from the query.
-	query := []issueActivity{}
-
-	if err := json.Unmarshal(c.Request().Body(), &query); err != nil {
-		return c.SendStatus(fiber.StatusUnprocessableEntity)
-	}
-
 	session, err := store.Get(c)
 	if err != nil {
 		log.Errorf("Failed to get session: %v", err)
@@ -492,6 +505,13 @@ func postFavoritesHandler(c *fiber.Ctx) error {
 	if err != nil {
 		log.Errorf("Failed to connect to database: %v", err)
 		return c.SendStatus(fiber.StatusInternalServerError)
+	}
+
+	// Parse the favoites from the query.
+	query := []issueActivity{}
+
+	if err := json.Unmarshal(c.Request().Body(), &query); err != nil {
+		return c.SendStatus(fiber.StatusUnprocessableEntity)
 	}
 
 	// Create a list of database.Favorite entries from the

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -495,12 +495,15 @@ func postFavoritesHandler(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
+	// The favorites are stored with the user's ID.
 	userId := session.Get("user_id")
 	if userId == nil {
 		log.Error("Failed to get vaid user ID from session")
 		return c.SendStatus(fiber.StatusUnauthorized)
 	}
 
+	// Fetch a database connection.
+	// FIXME: Do we want to do this only once for a session somehow?
 	db, err := database.New(config.Config.Database.Path)
 	if err != nil {
 		log.Errorf("Failed to connect to database: %v", err)

--- a/backend/internal/database/favorite.go
+++ b/backend/internal/database/favorite.go
@@ -34,7 +34,7 @@ func (db *database) GetAllUserFavorites(redmineUserId int) ([]Favorite, error) {
 	}
 	defer rows.Close()
 
-	favorites := make([]Favorite, 0)
+	var favorites []Favorite
 
 	for rows.Next() {
 		var favorite Favorite


### PR DESCRIPTION
This PR adds a new endpoint called `/api/favorites`.  Note that since this PR uses the refactored database API, it is dependent on PR #203; Closes #161.


- [x] GET method handler implementer to get all favorites.
   - [x] Initial method written.
   - [x] Uses same data model as the `/api/recent_issues` endpoint. 
- [x] POST method handler implemented to set all favorites.
- [x] Documentation
- [x] Any other necessary cleanup.

Results from the GET method on the endpoint use the same data model as the response from `/apt/recent_issues`:
```json
[
  {
    "issue": {
      "id": 3499,
      "subject": "NBIS General"
    },
    "activity": {
      "id": 19,
      "name": "Absence (Vacation/VAB/Other)"
    },
    "custom_name": "Test 4"
  },
  {...}, {...}, ...
]
```

These are the favorites of the user that is currently logged in, and they are given in the order they should appear in the frontend UI.

Note that the `custom_name` field will also be available (but always empty) in the response from `/api/recent_issues`.

The POST endpoint takes a query in the request's body containing the data in _the same_ format as the GET method returns and writes it to the local database, connecting it with the current user.