### PR TITLE
Dev/init db

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,40 +13,45 @@
 ### Local Redmine setup
 
 As a prerequisite for running Urdr during development, you need to run
-a local installation of Redmine. The NBIS Redmine installation is
+a local installation of Redmine.  The NBIS Redmine installation is
 currently maintained in the
 [ops-redmine repository](https://github.com/NBISweden/ops-redmine).
 
 Follow
 [the instructions](https://github.com/NBISweden/ops-redmine/blob/main/README.md)
-to set up and run Redmine locally. The repository may be cloned in a
+to set up and run Redmine locally.  The repository may be cloned in a
 separate directory, away from where you cloned the `urdr` repository.
 
 The setup of Redmine includes importing a database dump of Redmine
-in your local Redmine database. The database dump file should be
+in your local Redmine database.  The database dump file should be
 named `redmine_db.dump`, and it should be placed in that repository's
 `initdb.d` directory.
 
 ### Urdr setup
 
-1. In the top-most directory of the `urdr` repository, create the file
-   `urdr.env`, using `urdr.env.default` as the template. If you are
-   on Linux, you need to set the variable `REDMINE_HOST` to the value
-   `"http://172.17.0.1"`.
+In the top-most directory of the `urdr` repository, create the
+file `urdr.env`, using `urdr.env.default` as the template.  If you
+are on Linux, you need to set the variable `REDMINE_URL` to the
+value `"http://172.17.0.1:3000"`.  The `SNOWPACK_PUBLIC_API_URL`
+variable should be set to the URL from which the service is publically
+accessible, e.g. `"http://localhost:4567"` during development.
 
-2. Create a database for the Urdr backend containing the Urdr schema and
-   default values. From the top directory in the `urdr` repository.
+The database used by the Urdr backend containing the Urdr schema and
+default values is created automatically when it is first accessed by
+the backend Go code.  If this database, for whatever reason, needs to
+be manually be re-created, you may do so using the following set of
+commands:
 
-   ```shell
-   rm -f backend/database.db
-   sqlite3 backend/database.db <backend/sql/schema.sql
-   sqlite3 backend/database.db <backend/sql/setting-defaults.sql
-   ```
+```shell
+rm -f backend/database.db
+sqlite3 backend/database.db <backend/sql/schema.sql
+sqlite3 backend/database.db <backend/sql/setting-defaults.sql
+```
 
-   The name and location of the database file is configurable by setting
-   `BACKEND_DB_PATH` in the `urdr.env` file. The value of that variable
-   is a pathname relative to the `backend` directory, and the default
-   value is `./database.db`.
+The name and location of the database file are configurable by setting
+`BACKEND_DB_PATH` in the `urdr.env` file.  The value of that variable is
+a pathname relative to the `backend` directory, and the default value is
+`./database.db`.
 
 Finally, you can start Urdr by using:
 

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -422,6 +422,11 @@ func getFavoritesHandler(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
+	// If there are no favorites, return empty array and bail out here.
+	if len(favorites) == 0 {
+		return c.JSON([]struct{}{})
+	}
+
 	var issueActivities []issueActivity
 
 	for _, favorite := range favorites {

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -6,12 +6,15 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	// go-sqlite3 is the module for the SQLite3 database driver.
 	// It needs to be imported, but we're not actually using
 	// it explicitly in this module other than by referring to
 	// "sqlite3" when we create the database object in Setup().
 	_ "github.com/mattn/go-sqlite3"
+	log "github.com/sirupsen/logrus"
 )
 
 // A database contains a private method, handle(), that returns a handle
@@ -22,15 +25,61 @@ type database struct {
 
 // New() connects to the database, returns a database object.
 func New(databasePath string) (*database, error) {
+	initDB := false
+
+	if _, err := os.Stat(databasePath); err != nil {
+		log.Warningf("Database file not found at %q", databasePath)
+		initDB = true
+	}
+
 	handle, err := sql.Open("sqlite3",
-		fmt.Sprintf("%s?_auto_vacuum=FULL&_foreign_keys=true",
-			databasePath))
+		fmt.Sprintf("%s?%s&%s",
+			databasePath,
+			"_auto_vacuum=FULL",
+			"_foreign_keys=true",
+		))
 	if err != nil {
 		return nil, fmt.Errorf("sql.Open() failed: %w", err)
 	}
 
 	if err := handle.Ping(); err != nil {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
+	}
+
+	if initDB {
+		log.Warningln("Initializing database")
+
+		tx, err := handle.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("sql.Begin() failed: %w", err)
+		}
+
+		// Read the two files containing the schema and the
+		// available user-specific settings, and run them to
+		// initialize the database.
+		files := []string{
+			"sql/schema.sql",
+			"sql/setting-defaults.sql",
+		}
+
+		for i := range files {
+			query, err := ioutil.ReadFile(files[i])
+			if err != nil {
+				tx.Rollback()
+				return nil,
+					fmt.Errorf("ioutil.ReadFile() failed: %w", err)
+			}
+			if _, err := tx.Exec(string(query)); err != nil {
+				tx.Rollback()
+				return nil,
+					fmt.Errorf("sql.Tx.Exec() failed: %w", err)
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			tx.Rollback()
+			return nil, fmt.Errorf("sql.Tx.Commit() failed: %w", err)
+		}
 	}
 
 	return &database{handle: func() *sql.DB { return handle }}, nil

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -65,19 +65,19 @@ func New(databasePath string) (*database, error) {
 		for i := range files {
 			query, err := ioutil.ReadFile(files[i])
 			if err != nil {
-				tx.Rollback()
+				_ = tx.Rollback()
 				return nil,
 					fmt.Errorf("ioutil.ReadFile() failed: %w", err)
 			}
 			if _, err := tx.Exec(string(query)); err != nil {
-				tx.Rollback()
+				_ = tx.Rollback()
 				return nil,
 					fmt.Errorf("sql.Tx.Exec() failed: %w", err)
 			}
 		}
 
 		if err := tx.Commit(); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return nil, fmt.Errorf("sql.Tx.Commit() failed: %w", err)
 		}
 	}

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -17,15 +17,13 @@
 -- on Ubuntu.  The utility is part of the macOS base system and does not
 -- need to be installed separately.
 
+PRAGMA auto_vacuum = FULL;
+PRAGMA foreign_keys = ON;
+
 -- FIXME:
 -- The datatype for the fields whose names start with "redmine_" are
 -- currently unknown, so we assume that they are INTEGER in the schema
 -- below.
-
-PRAGMA auto_vacuum = FULL;
-PRAGMA foreign_keys = ON;
-
-BEGIN;
 
 -- Settings.
 -- A "setting" is a "name" and a "value".  The "name" is the name of
@@ -82,5 +80,3 @@ CREATE TABLE favorite (
 	UNIQUE (redmine_user_id, redmine_issue_id, redmine_activity_id)
 		ON CONFLICT REPLACE
 );
-
-COMMIT;

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -17,13 +17,13 @@
 -- on Ubuntu.  The utility is part of the macOS base system and does not
 -- need to be installed separately.
 
-PRAGMA auto_vacuum = FULL;
-PRAGMA foreign_keys = ON;
-
 -- FIXME:
 -- The datatype for the fields whose names start with "redmine_" are
 -- currently unknown, so we assume that they are INTEGER in the schema
 -- below.
+
+PRAGMA auto_vacuum = FULL;
+PRAGMA foreign_keys = ON;
 
 -- Settings.
 -- A "setting" is a "name" and a "value".  The "name" is the name of

--- a/backend/sql/setting-defaults.sql
+++ b/backend/sql/setting-defaults.sql
@@ -4,9 +4,8 @@
 --
 --	sqlite3 database.db <setting-defaults.sql
 
+PRAGMA auto_vacuum = FULL;
 PRAGMA foreign_keys = ON;
-
-BEGIN;
 
 -- "Default days"
 -- https://github.com/NBISweden/urdr/issues/22
@@ -48,5 +47,3 @@ INSERT INTO setting (name, value) VALUES
 
 INSERT INTO setting (name, value) VALUES
 	('input', 'daily');	-- or 'weekly'
-
-COMMIT;


### PR DESCRIPTION
This PR causes the Go code to automatically create the local SQLite3 database file if it is missing when the database is accessed.  It does this by reading and executing the two SQL files `schema.sql` and `setting-defualts.sql` in `backend/sql`.

This means that we no longer need to manually initialize the local database from the command line.  Using the SQL from the files also means that we're still able to initialize the database manually, using the same commands as before, if we wish or need to do so.

The PR also fixes a small bug: The `/api/favorites` endpoint for the GET method tried to populate the `subject` field for issues even if the user did not have favorites stored, which caused an error to be reported from Redmine.

Closes #209 