### PR TITLE
Reduce api calls for favorites

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -124,9 +124,7 @@ export const Report = () => {
   }, [recentIssues]);
 
   const handleCellUpdate = (timeEntry: TimeEntry): void => {
-    const entries = newTimeEntries.map((entry) => {
-      return entry;
-    });
+    const entries = [...newTimeEntries];
     const existingEntry = entries.find(
       (entry) =>
         entry.issue_id === timeEntry.issue_id &&
@@ -176,7 +174,7 @@ export const Report = () => {
       }
       getRowTopics();
     } else {
-      const favs = favorites.map((fav) => fav);
+      const favs = [...favorites];
       const removed = favs.find(
         (fav) =>
           fav.activity.id === topic.activity.id &&


### PR DESCRIPTION
A new state variable `filteredRecents` is added to keep a filtered list of recent issues. This one keeps all recent issues minus those that already appear in the list of favorites. 
This way, `recentIssues` keeps an unmodified list of recent issues fetched from the backend on first page render. 
This one can be reused when favorites are modified and no additional call to `/recent_issues` is necessary. 

Also some minor refactoring with using the spread operator instead of `map` to create shallow copies of arrays.

Fixes #217 