### PR TITLE
Also include assigned issues in the list of "recent issues"

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -45,6 +45,9 @@ func fetchIssueSubjects(c *fiber.Ctx, entries []Entry) (bool, error) {
 	var issueIds []string
 
 	for _, entry := range entries {
+		if entry.Issue.Subject != "" {
+			continue
+		}
 		issueId := entry.Issue.Id
 		if !seenIssueIds[issueId] {
 			seenIssueIds[issueId] = true
@@ -80,6 +83,9 @@ func fetchIssueSubjects(c *fiber.Ctx, entries []Entry) (bool, error) {
 	// subject to each issue from the issuesResponse structure.
 
 	for i := range entries {
+		if entries[i].Issue.Subject != "" {
+			continue
+		}
 		for _, issue := range issuesResponse.Issues {
 			if issue.Id == entries[i].Issue.Id {
 				entries[i].Issue.Subject = issue.Subject


### PR DESCRIPTION
The 100 most recent (with regard to issue ID) open issues that the user was assigned to are added to the list of issues returned from the `/api/recent_issues` endpoint.  An issue is added if it has not already been seen in among the 100 most recent time entries.

**Note that these new issues will not have a corresponding activity and that reporting time on any of these entries will result in an error.**


Closes #237 
