### PR TITLE
Check returned values closer to function call

### DIFF
--- a/backend/api/getPriorityEntriesHandler.go
+++ b/backend/api/getPriorityEntriesHandler.go
@@ -41,11 +41,9 @@ func getPriorityEntriesHandler(c *fiber.Ctx) error {
 	if err != nil {
 		log.Errorf("Failed to get priority entries for user ID %d: %v", userId.(int), err)
 		return c.SendStatus(fiber.StatusInternalServerError)
-	}
-
-	// If there are no priority entries,
-	// return empty array and bail out here.
-	if len(dbPriorityEntries) == 0 {
+	} else if len(dbPriorityEntries) == 0 {
+		// If there are no priority entries,
+		// return empty array and bail out here.
 		return c.JSON([]struct{}{})
 	}
 


### PR DESCRIPTION
This PR is a very minor modification to a single file that moves a test of a returned value semantically closer to the function call that produced it.

This is the only code change that I found that was relevant in relation to issue #247 

In my opinion, this closes #247 