### PR TITLE
Dev/extended sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 *.code-workspace
+*.db
 *.env
 .vscode/
 /backend/tmp/
 /backend/urdr
 /backend/vendor/
 /frontend/node_modules/
-database.db
 ops-redmine/

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -6,6 +6,7 @@ import (
 	fiberSwagger "github.com/swaggo/fiber-swagger"
 
 	_ "urdr-api/docs"
+	"urdr-api/internal/config"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
@@ -30,7 +31,7 @@ func Setup() *fiber.App {
 	app := fiber.New()
 
 	storage := sqlite3.New(sqlite3.Config{
-		Database:   "session.db",
+		Database:   config.Config.App.SessionDBPath,
 		Table:      "session",
 		GCInterval: 1 * time.Hour,
 	})

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -29,7 +29,7 @@ func Setup() *fiber.App {
 	app := fiber.New()
 
 	store = session.New(session.Config{
-		Expiration:     time.Minute * 15,
+		Expiration:     (7 * 24 /* A week in hours */) * time.Hour,
 		KeyLookup:      "cookie:urdr_session",
 		CookieSecure:   true,
 		CookieSameSite: "Strict",

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
+	"github.com/gofiber/storage/sqlite3"
 )
 
 var store *session.Store
@@ -28,11 +29,18 @@ func Setup() *fiber.App {
 	// Fiber instance
 	app := fiber.New()
 
+	storage := sqlite3.New(sqlite3.Config{
+		Database:   "session.db",
+		Table:      "session",
+		GCInterval: 1 * time.Hour,
+	})
+
 	store = session.New(session.Config{
 		Expiration:     (7 * 24 /* A week in hours */) * time.Hour,
 		KeyLookup:      "cookie:urdr_session",
 		CookieSecure:   true,
 		CookieSameSite: "Strict",
+		Storage:        storage,
 	})
 
 	app.Get("/swagger/*", fiberSwagger.WrapHandler)

--- a/backend/api/handlers_test.go
+++ b/backend/api/handlers_test.go
@@ -41,6 +41,8 @@ func TestMain(m *testing.M) {
 
 	test_db_path := "./testdata/database.db"
 	_ = os.Remove(test_db_path)
+	test_sessiondb_path := "./testdata/session.db"
+	_ = os.Remove(test_sessiondb_path)
 
 	err = config.Setup()
 	if err != nil {
@@ -48,6 +50,7 @@ func TestMain(m *testing.M) {
 	}
 
 	config.Config.Database.Path = test_db_path
+	config.Config.App.SessionDBPath = test_sessiondb_path
 
 	app = api.Setup()
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/gofiber/fiber/v2 v2.31.0
+	github.com/gofiber/storage/sqlite3 v0.0.0-20220331080057-83339bc1564f
 	github.com/mattn/go-sqlite3 v1.14.12
 	github.com/sirupsen/logrus v1.8.1
 	github.com/swaggo/fiber-swagger v1.2.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -30,6 +30,10 @@ github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/e
 github.com/gofiber/fiber/v2 v2.26.0/go.mod h1:7efVWcBOZi1PyMWznnbitjnARPA7nYZxmQXJVod0bo0=
 github.com/gofiber/fiber/v2 v2.31.0 h1:M2rWPQbD5fDVAjcoOLjKRXTIlHesI5Eq7I5FEQPt4Ow=
 github.com/gofiber/fiber/v2 v2.31.0/go.mod h1:1Ega6O199a3Y7yDGuM9FyXDPYQfv+7/y48wl6WCwUF4=
+github.com/gofiber/storage/sqlite3 v0.0.0-20220331080057-83339bc1564f h1:MsAiXO6u6fHcFCJ9l1xA50bhbdNsfsc9Qvw85kF1ycM=
+github.com/gofiber/storage/sqlite3 v0.0.0-20220331080057-83339bc1564f/go.mod h1:uXVJ86vjb0REU4m/zO+O4c/FziidoQWPH2Z9R369v8A=
+github.com/gofiber/utils v0.1.2 h1:1SH2YEz4RlNS0tJlMJ0bGwO0JkqPqvq6TbHK9tXZKtk=
+github.com/gofiber/utils v0.1.2/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,8 +15,9 @@ type ConfigMap struct {
 }
 
 type AppConfig struct {
-	Host string
-	Port string
+	Host          string
+	Port          string
+	SessionDBPath string
 }
 
 type RedmineConfig struct {
@@ -43,6 +44,7 @@ func Setup() error {
 
 	Config.App.Host = getEnv("BACKEND_HOST", "127.0.0.1")
 	Config.App.Port = getEnv("BACKEND_PORT", "8080")
+	Config.App.SessionDBPath = getEnv("SESSION_DB_PATH", "./session.db")
 
 	Config.Redmine.URL = getEnv("REDMINE_URL", "http://redmine:3000")
 

--- a/urdr.env.default
+++ b/urdr.env.default
@@ -1,5 +1,6 @@
 BACKEND_DB_PATH="./database.db"
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8080
-SNOWPACK_PUBLIC_API_URL="http://localhost:4567"
 REDMINE_URL="http://host.docker.internal:3000"
+SESSION_DB_PATH="./session.db"
+SNOWPACK_PUBLIC_API_URL="http://localhost:4567"


### PR DESCRIPTION
In this PR:

* The initial session expiry time is extended from 15 minutes to 1 week (7*24 hours).
* Session expiry times are extended to 1 week whenever the `/api/time_entries` POST endpoint is called; this roughly corresponds to when the user clicks the "Save changes" button in the UI.

Since we're moving to rather long sessions, it makes sense to begin storing sessions in a persistent database.  Therefore:
* Sessions are stored in a `session.db` SQLite3 database.
* As a consequence of the previous point, sessions are now persistent; sessions are not forgotten on service restarts.

Closes #246 

Possibly further change: Make the `database.db` database filename used by the backend's database API a static string in the code. There is no real point in making this configurable.
