### PR TITLE
Create database connection when we set up application

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -1,17 +1,21 @@
 package api
 
 import (
+	"log"
 	"time"
 
 	fiberSwagger "github.com/swaggo/fiber-swagger"
 
 	_ "urdr-api/docs"
+	"urdr-api/internal/config"
+	"urdr-api/internal/database"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
 )
 
 var store *session.Store
+var db *database.Database
 
 // @title Urdr API
 // @version 1.0
@@ -34,6 +38,13 @@ func Setup() *fiber.App {
 		CookieSecure:   true,
 		CookieSameSite: "Strict",
 	})
+
+	var err error
+	db, err = database.New(config.Config.Database.Path)
+	if err != nil {
+		log.Fatalf("Failed to connect to backend database: %v", err)
+		return nil
+	}
 
 	app.Get("/swagger/*", fiberSwagger.WrapHandler)
 

--- a/backend/api/getPriorityEntriesHandler.go
+++ b/backend/api/getPriorityEntriesHandler.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"urdr-api/internal/config"
-	"urdr-api/internal/database"
 
 	"github.com/gofiber/fiber/v2"
 	log "github.com/sirupsen/logrus"
@@ -29,12 +27,6 @@ func getPriorityEntriesHandler(c *fiber.Ctx) error {
 	if userId == nil {
 		log.Error("Failed to get valid user ID from session")
 		return c.SendStatus(fiber.StatusUnauthorized)
-	}
-
-	db, err := database.New(config.Config.Database.Path)
-	if err != nil {
-		log.Errorf("Failed to connect to database: %v", err)
-		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
 	dbPriorityEntries, err := db.GetAllUserPrioityEntries(userId.(int))

--- a/backend/api/postPriorityEntriesHandler.go
+++ b/backend/api/postPriorityEntriesHandler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"urdr-api/internal/config"
 	"urdr-api/internal/database"
 
 	"github.com/gofiber/fiber/v2"
@@ -31,14 +30,6 @@ func postPriorityEntriesHandler(c *fiber.Ctx) error {
 	if userId == nil {
 		log.Error("Failed to get valid user ID from session")
 		return c.SendStatus(fiber.StatusUnauthorized)
-	}
-
-	// Fetch a database connection.
-	// FIXME: Do we want to do this only once for a session somehow?
-	db, err := database.New(config.Config.Database.Path)
-	if err != nil {
-		log.Errorf("Failed to connect to database: %v", err)
-		return c.SendStatus(fiber.StatusInternalServerError)
 	}
 
 	// Parse the entries from the query.

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -19,16 +19,16 @@ import (
 
 // A database contains a private method, handle(), that returns a handle
 // to the underlying database connection handle.
-type database struct {
+type Database struct {
 	handle func() *sql.DB
 }
 
 // New() connects to the database, returns a database object.
-func New(databasePath string) (*database, error) {
+func New(databasePath string) (*Database, error) {
 	initDB := false
 
 	if _, err := os.Stat(databasePath); err != nil {
-		log.Warningf("Database file not found at %q", databasePath)
+		log.Warningf("Database file not found at %v", databasePath)
 		initDB = true
 	}
 
@@ -82,5 +82,5 @@ func New(databasePath string) (*database, error) {
 		}
 	}
 
-	return &database{handle: func() *sql.DB { return handle }}, nil
+	return &Database{handle: func() *sql.DB { return handle }}, nil
 }

--- a/backend/internal/database/priorityEntry.go
+++ b/backend/internal/database/priorityEntry.go
@@ -15,7 +15,7 @@ type PriorityEntry struct {
 
 // GetAllUserPrioityEntries() returns a list of priority entries for
 // a particular user.
-func (db *database) GetAllUserPrioityEntries(redmineUserId int) ([]PriorityEntry, error) {
+func (db *Database) GetAllUserPrioityEntries(redmineUserId int) ([]PriorityEntry, error) {
 	selectStmt := `
 		SELECT
 			redmine_issue_id,
@@ -61,7 +61,7 @@ func (db *database) GetAllUserPrioityEntries(redmineUserId int) ([]PriorityEntry
 
 // SetAllUserPriorityEntries() replaces all stored priority entries for the given
 // user by the ones provided in the list to this function.
-func (db *database) SetAllUserPriorityEntries(redmineUserId int, favorites []PriorityEntry) error {
+func (db *Database) SetAllUserPriorityEntries(redmineUserId int, favorites []PriorityEntry) error {
 	tx, err := db.handle().Begin()
 	if err != nil {
 		return fmt.Errorf("sql.Begin() failed: %w", err)
@@ -129,7 +129,7 @@ func (db *database) SetAllUserPriorityEntries(redmineUserId int, favorites []Pri
 
 // DeleteAllUserPriorityEntries() removes all stored priority entries
 // for the given user.
-func (db *database) DeleteAllUserPriorityEntries(redmineUserId int) error {
+func (db *Database) DeleteAllUserPriorityEntries(redmineUserId int) error {
 	deleteStmt := `
 		DELETE FROM priority_entry
 		WHERE	redmine_user_id = ?`

--- a/backend/internal/database/setting.go
+++ b/backend/internal/database/setting.go
@@ -18,7 +18,7 @@ type Setting struct {
 // getSetting() is an internal function that returns the setting struct
 // (setting ID, name and value), given the setting's name.  It returns
 // an error for illegal settings.
-func (db *database) getSetting(settingName string) (*Setting, error) {
+func (db *Database) getSetting(settingName string) (*Setting, error) {
 	if err := db.handle().Ping(); err != nil {
 		return nil, fmt.Errorf("sql.Ping() failed: %w", err)
 	}
@@ -76,7 +76,7 @@ func (db *database) getSetting(settingName string) (*Setting, error) {
 // user-specific value for a particular setting.  If there is no
 // user-specific value stored for the given user, then the default value
 // is returned, if there is one.
-func (db *database) GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
+func (db *Database) GetUserSetting(redmineUserId int, settingName string) (*Setting, error) {
 	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return nil, fmt.Errorf("getSetting() failed: %w", err)
@@ -125,7 +125,7 @@ func (db *database) GetUserSetting(redmineUserId int, settingName string) (*Sett
 // SetUserSetting() assigns the user-specific value for a particular
 // setting.  If there is already a user-specific value stored for the
 // given setting, the new value replaces the old value.
-func (db *database) SetUserSetting(redmineUserId int, settingName string, settingValue string) error {
+func (db *Database) SetUserSetting(redmineUserId int, settingName string, settingValue string) error {
 	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return fmt.Errorf("getSetting() failed: %w", err)
@@ -150,7 +150,7 @@ func (db *database) SetUserSetting(redmineUserId int, settingName string, settin
 
 // DeleteUserSetting() removes the user-specific value for a particular
 // setting.
-func (db *database) DeleteUserSetting(redmineUserId int, settingName string) error {
+func (db *Database) DeleteUserSetting(redmineUserId int, settingName string) error {
 	setting, err := db.getSetting(settingName)
 	if err != nil {
 		return fmt.Errorf("getSetting() failed: %w", err)


### PR DESCRIPTION
This PR reorganizes the way connections are made to the backend database.

Instead of establishing a new connection each time an endpoint is called, we make a connection when the application starts and then hold on to it throughout the application's lifetime.

This reduces the need for re-establishing database connections and it does not needlessly cause writes to the database file for each access from the frontend.

Closes #258 