### PR TITLE
responsive dates & updated list layout

### DIFF
--- a/frontend/src/components/HeaderRow.tsx
+++ b/frontend/src/components/HeaderRow.tsx
@@ -1,19 +1,42 @@
 import React from "react";
+import {
+  getLongCustomDateString,
+  getShortCustomDateString,
+  useViewport,
+} from "../utils";
 
-export const HeaderRow = ({ title, days }: { title: string; days: Date[] }) => {
-  const dayStrings = days.map((day) => {
-    return day.toISOString().split("T")[0];
+export const HeaderRow = ({ days }: { days: Date[] }) => {
+  const { width } = useViewport();
+  const breakpoint = 1044;
+  const longDayStrings = days.map((day) => {
+    return getLongCustomDateString(day);
   });
+
+  const shortDayStrings = days.map((day) => {
+    return getShortCustomDateString(day);
+  });
+
+  const Dates = ({ dayStrings }: { dayStrings: string[] }) => {
+    return (
+      <>
+        {dayStrings.map((day, index) => {
+          return (
+            <p key={day} className={index === 0 ? "col-1 offset-6" : "col-1"}>
+              {day}
+            </p>
+          );
+        })}
+      </>
+    );
+  };
+
   return (
     <div className="row">
-      <h2 className="col-6">{title}</h2>
-      {dayStrings.map((day) => {
-        return (
-          <p key={day} className="col-1">
-            {day}
-          </p>
-        );
-      })}
+      {width >= breakpoint ? (
+        <Dates dayStrings={longDayStrings} />
+      ) : (
+        <Dates dayStrings={shortDayStrings} />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/HeaderRow.tsx
+++ b/frontend/src/components/HeaderRow.tsx
@@ -7,7 +7,7 @@ import {
 
 export const HeaderRow = ({ days }: { days: Date[] }) => {
   const { width } = useViewport();
-  const breakpoint = 1044;
+  const breakpoint = 1267; // below this, the default date format "Mon 24/12" won't fit
   const longDayStrings = days.map((day) => {
     return getLongCustomDateString(day);
   });

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -86,7 +86,7 @@ export const Row = ({
 
   return (
     <>
-      <div className="row issue-row">
+      <div className="row">
         <div className="col-1 cell-container grip-container">
           {isFav ? <img src={grip} className="grip" /> : <div></div>}
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,11 +126,13 @@ input[type="number"] {
 
 .recent-container {
   background-color: hsl(0deg 0% 97%);
-  padding: 1.5rem;
+  padding: 0.5rem 1.5rem 2.5rem 1.5rem;
 }
 
-.issue-row {
-  padding: 0.75rem 0;
+.favorites-container {
+  background-color: hsl(0deg 0% 97%);
+  padding: 2.5rem 1.5rem 0.5rem 1.5rem;
+  margin-bottom: 0.2rem;
 }
 
 .issue-label {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,12 +126,12 @@ input[type="number"] {
 
 .recent-container {
   background-color: hsl(0deg 0% 97%);
-  padding: 0.5rem 1.5rem 2.5rem 1.5rem;
+  padding: 0.5rem 1.5rem 2.5rem;
 }
 
 .favorites-container {
   background-color: hsl(0deg 0% 97%);
-  padding: 2.5rem 1.5rem 0.5rem 1.5rem;
+  padding: 2.5rem 1.5rem 0.5rem;
   margin-bottom: 0.2rem;
 }
 

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -241,8 +241,8 @@ export const Report = () => {
       />
       {favorites.length > 0 ? (
         <DragDropContext onDragEnd={onDragEnd}>
-          <section className="recent-container">
-            <HeaderRow days={currentWeekArray} title="Favorites" />
+          <section className="favorites-container">
+            <HeaderRow days={currentWeekArray} />
             <Droppable droppableId="favorites">
               {(provided) => (
                 <div {...provided.droppableProps} ref={provided.innerRef}>
@@ -292,10 +292,7 @@ export const Report = () => {
         <div></div>
       )}
       <section className="recent-container">
-        <HeaderRow
-          days={favorites.length > 0 ? [] : currentWeekArray}
-          title="Recent issues"
-        />
+        <HeaderRow days={favorites.length > 0 ? [] : currentWeekArray} />
         {filteredRecents &&
           filteredRecents.map((recentIssue) => {
             const rowUpdates = newTimeEntries?.filter(

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -62,17 +62,25 @@ export const getLongCustomDateString = (day: Date) => {
   const getWeekDay = () => {
     let dayString = "";
     const dayNumber = day.getDay();
-    dayNumber === 1
-      ? (dayString = "Mon")
-      : dayNumber === 2
-      ? (dayString = "Tue")
-      : dayNumber === 3
-      ? (dayString = "Wed")
-      : dayNumber === 4
-      ? (dayString = "Thu")
-      : dayNumber === 5
-      ? (dayString = "Fri")
-      : (dayString = "");
+    switch (dayNumber) {
+      case 1:
+        "Mon";
+        break;
+      case 2:
+        "Tue";
+        break;
+      case 3:
+        "Wed";
+        break;
+      case 4:
+        "Thu";
+        break;
+      case 5:
+        "Fri";
+        break;
+      default:
+        "";
+    }
     return dayString;
   };
   const weekDay = getWeekDay();
@@ -82,9 +90,7 @@ export const getLongCustomDateString = (day: Date) => {
 };
 
 export const getShortCustomDateString = (day: Date) => {
-  const date = day.getDate();
-  const month = day.getMonth();
-  return `${date}/${month}`;
+  return `${day.getDate()}/${day.getMonth()}`;
 };
 
 export const useDebounce = (value, delay) => {
@@ -108,8 +114,12 @@ export const useViewport = () => {
   const [width, setWidth] = React.useState(window.innerWidth);
 
   React.useEffect(() => {
+    // Whenever the window is resized, the "width" state veriable will be updated
     const handleWindowResize = () => setWidth(window.innerWidth);
     window.addEventListener("resize", handleWindowResize);
+
+    // Clean-up: Return a function from the effect that removes the event listener...
+    // ...when the user leaves the page and the component unmounts.
     return () => window.removeEventListener("resize", handleWindowResize);
   }, []);
 

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -64,33 +64,33 @@ export const getLongCustomDateString = (day: Date) => {
     const dayNumber = day.getDay();
     switch (dayNumber) {
       case 1:
-        "Mon";
+        dayString = "Mon";
         break;
       case 2:
-        "Tue";
+        dayString = "Tue";
         break;
       case 3:
-        "Wed";
+        dayString = "Wed";
         break;
       case 4:
-        "Thu";
+        dayString = "Thu";
         break;
       case 5:
-        "Fri";
+        dayString = "Fri";
         break;
       default:
-        "";
+        dayString = "";
     }
     return dayString;
   };
   const weekDay = getWeekDay();
   const date = day.getDate();
-  const month = day.getMonth();
+  const month = day.getMonth() + 1;
   return `${weekDay} ${date}/${month}`;
 };
 
 export const getShortCustomDateString = (day: Date) => {
-  return `${day.getDate()}/${day.getMonth()}`;
+  return `${day.getDate()}/${day.getMonth() + 1}`;
 };
 
 export const useDebounce = (value, delay) => {

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -58,6 +58,35 @@ export const getFullWeek = (today: Date): Date[] => {
   return fullWeek;
 };
 
+export const getLongCustomDateString = (day: Date) => {
+  const getWeekDay = () => {
+    let dayString = "";
+    const dayNumber = day.getDay();
+    dayNumber === 1
+      ? (dayString = "Mon")
+      : dayNumber === 2
+      ? (dayString = "Tue")
+      : dayNumber === 3
+      ? (dayString = "Wed")
+      : dayNumber === 4
+      ? (dayString = "Thu")
+      : dayNumber === 5
+      ? (dayString = "Fri")
+      : (dayString = "");
+    return dayString;
+  };
+  const weekDay = getWeekDay();
+  const date = day.getDate();
+  const month = day.getMonth();
+  return `${weekDay} ${date}/${month}`;
+};
+
+export const getShortCustomDateString = (day: Date) => {
+  const date = day.getDate();
+  const month = day.getMonth();
+  return `${date}/${month}`;
+};
+
 export const useDebounce = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
   React.useEffect(() => {
@@ -73,4 +102,17 @@ export const useDebounce = (value, delay) => {
     };
   }, [value, delay]);
   return debouncedValue;
+};
+
+export const useViewport = () => {
+  const [width, setWidth] = React.useState(window.innerWidth);
+
+  React.useEffect(() => {
+    const handleWindowResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", handleWindowResize);
+    return () => window.removeEventListener("resize", handleWindowResize);
+  }, []);
+
+  // Return the width so we can use it in our components
+  return { width };
 };


### PR DESCRIPTION
The dates are now displayed in the format specified in the mockup: "Mon 21/5"
When the window is smaller than the width that would fit this format, the weekday is removed: "21/5"

The `useViewport` hook built for this can potentially be reused in the future to make other parts of the UI more responsive.

This fixes #282 and fixes #286