### PR TITLE
rename Header to LoginHeader

### DIFF
--- a/frontend/src/components/LoginHeader.tsx
+++ b/frontend/src/components/LoginHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "../index.css";
 
-export const Header = () => {
+export const LoginHeader = () => {
   return (
     <section className="header-wrapper">
       <h1 className="header-heading">Welcome to urdr</h1>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Buffer } from "buffer";
-import { Header } from "../components/Header";
+import { LoginHeader } from "../components/LoginHeader";
 import "../index.css";
 import { User } from "../model";
 import { SNOWPACK_PUBLIC_API_URL } from "../utils";
@@ -48,7 +48,7 @@ export const Login = () => {
 
   return (
     <div className="login-wrapper">
-      <Header />
+      <LoginHeader />
       <form onSubmit={authenticateRedmine} className="login-form">
         <label htmlFor="username">Username</label>
         <input


### PR DESCRIPTION
The `<Header />` component was created when we made the login page, under the assumption that it would be reused on the report page. This turned out not to be the case and now there are several components containing the word "Header". 

I figured it would be better to be more precise here to avoid confusion. 