### PR TITLE
Added spa fallback paths in conf

### DIFF
--- a/frontend/snowpack.config.mjs
+++ b/frontend/snowpack.config.mjs
@@ -9,8 +9,11 @@ export default {
     /* ... */
   ],
   routes: [
-    /* Enable an SPA Fallback in development: */
-    // {"match": "routes", "src": ".*", "dest": "/index.html"},
+    {
+      match: 'routes',
+      src: '.*',
+      dest: '/index.html',
+    },
   ],
   optimize: {
   },

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,9 +6,9 @@ server {
         proxy_pass http://node-urdr:4242/;
     }
 
-    location /report {
-        proxy_pass http://node-urdr:4242/;
-    }
+#    location /report {
+ #       proxy_pass http://node-urdr:4242/;
+  #  }
 
     location /api/ {
         proxy_pass http://urdr:8080/api/;


### PR DESCRIPTION
Adding a spa fallback path in snowpack config, then we do not need to specify a location for each react route in nginx conf. 
This will probably make the development a bit simpler. 