### PR TITLE
 Add attempt to extend sessions

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -40,7 +40,7 @@ func Setup() *fiber.App {
 	})
 
 	store = session.New(session.Config{
-		Expiration:     time.Minute,
+		Expiration:     (7 * 24 /* A week in hours */) * time.Hour,
 		KeyLookup:      "cookie:urdr_session",
 		CookieSecure:   true,
 		CookieSameSite: "Strict",

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -40,7 +40,7 @@ func Setup() *fiber.App {
 	})
 
 	store = session.New(session.Config{
-		Expiration:     (7 * 24 /* A week in hours */) * time.Hour,
+		Expiration:     time.Minute,
 		KeyLookup:      "cookie:urdr_session",
 		CookieSecure:   true,
 		CookieSameSite: "Strict",

--- a/backend/api/handlers_test.go
+++ b/backend/api/handlers_test.go
@@ -400,7 +400,7 @@ func Test_Handlers(t *testing.T) {
 				t.Errorf("StatusCode was incorrect, got: %d, want: %d.", statusCode, tt.statusCode)
 			}
 
-			if tt.name == "Login" {
+			if tt.name == "Login" || tt.name == "Time entry POST" {
 				urdrSessionHeader = resp.Header.Get("Set-Cookie")
 			}
 

--- a/backend/api/postTimeEntriesHandler.go
+++ b/backend/api/postTimeEntriesHandler.go
@@ -79,7 +79,10 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 	} else {
 		// Extend the session's expiry time to a week.
 		session.SetExpiry((7 * 24 /* A week in hours */) * time.Hour)
-		session.Regenerate()
+		if err := session.Regenerate(); err != nil {
+			log.Errorf("session.Regenerate() failed: %v\n", err)
+			return c.SendStatus(fiber.StatusInternalServerError)
+		}
 
 		if err := session.Save(); err != nil {
 			log.Errorf("session.Save() failed: %v\n", err)

--- a/backend/api/postTimeEntriesHandler.go
+++ b/backend/api/postTimeEntriesHandler.go
@@ -77,7 +77,6 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 	if session, err := store.Get(c); err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	} else {
-		c.Response().Reset()
 		// Extend the session's expiry time to a week.
 		session.SetExpiry((7 * 24 /* A week in hours */) * time.Hour)
 		session.Regenerate()

--- a/backend/api/postTimeEntriesHandler.go
+++ b/backend/api/postTimeEntriesHandler.go
@@ -73,14 +73,14 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 		log.Errorf("proxy.Do() failed: %v\n", err)
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
-	c.Response().Reset()
 
 	if session, err := store.Get(c); err != nil {
 		return c.SendStatus(fiber.StatusInternalServerError)
 	} else {
-		log.Debug("Session: ", session)
+		c.Response().Reset()
 		// Extend the session's expiry time to a week.
 		session.SetExpiry((7 * 24 /* A week in hours */) * time.Hour)
+		session.Regenerate()
 
 		if err := session.Save(); err != nil {
 			log.Errorf("session.Save() failed: %v\n", err)


### PR DESCRIPTION
This PR addresses the issue of sessions not being extended on the client side.

The current approach is to regenerate a user session upon a successful POST request to the time entries handler.

Closes #317 