### PR TITLE
show issue number in rows

### DIFF
--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -92,21 +92,28 @@ export const Row = ({
           {isFav ? <img src={grip} className="grip" /> : <div></div>}
         </div>
         <div className="col-4 ">
-          <p className="issue-label">
-            {topic.custom_name
-              ? `${topic.custom_name}`
-              : `${topic.issue.subject} - ${topic.activity.name}`}
-          </p>
+          <div className="issue-label">
+            <p className="issue-label-text">{`# ${topic.issue.id}`}</p>
+            <p className="issue-label-text">
+              {topic.custom_name
+                ? `${topic.custom_name}`
+                : `${topic.issue.subject} - ${topic.activity.name}`}
+            </p>
+          </div>
         </div>
         <div className="col-1 star-container">
-	<button type="button" className="star-button" onClick={() => onToggleFav(topic)}>
-          <img
-            src={isFav ? fillStar : star}
-            className="star"
-            role="button"
-            alt={isFav ? "Remove from favorites" : "Make favorite"}
-          />
-	  </button>
+          <button
+            type="button"
+            className="star-button"
+            onClick={() => onToggleFav(topic)}
+          >
+            <img
+              src={isFav ? fillStar : star}
+              className="star"
+              role="button"
+              alt={isFav ? "Remove from favorites" : "Make favorite"}
+            />
+          </button>
         </div>
         {days.map((day, i) => {
           return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,6 +203,12 @@ input[type="number"] {
   background-color: white;
   padding: 0.5rem 0.75rem;
   margin: 0.5rem 0;
+  display: flex;
+}
+
+.issue-label-text {
+  margin: 0;
+  min-width: 4rem;
 }
 
 .basic-button {


### PR DESCRIPTION
Now you should see the issue number in the start of each row. When looking at a small screen, the test should wrap, but the number still be separated in the front. 

OBS: You see GitHub marking some "changes" on the star button / star img. These are only formatting changes that happened when I saved the file. I think it was changes Konny made in his last PR and he doesn't know yet that we use Prettier for formatting. I'll let him know.

This fixes #143.