### PR TITLE
Get issue subjects also for closed issues

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -56,7 +56,8 @@ func fetchIssueSubjects(c *fiber.Ctx, entries []Entry) (bool, error) {
 	// the issue subjects for the issue IDs in the issueIds list.
 
 	c.Request().URI().SetQueryString(
-		fmt.Sprintf("issue_id=%s", strings.Join(issueIds, ",")))
+		fmt.Sprintf("issue_id=%s&status_id=*",
+			strings.Join(issueIds, ",")))
 
 	c.Response().Reset()
 	if err := getIssuesHandler(c); err != nil {


### PR DESCRIPTION
In this PR, the parameter `status_id` with the value `*` is added to the call to the Redmine `/issue.json` endpoint when we fetch issues for figuring out their subject text.  This allows us to also fill out the text for closed issues.

Closes #320 