### PR TITLE
Reduce API calls for favorites

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -12,6 +12,7 @@ import {
   getApiEndpoint,
   headers,
   getFullWeek,
+  removeIssueActivityPair,
 } from "../utils";
 import { TimeTravel } from "../components/TimeTravel";
 import { format as formatDate } from "date-fns";
@@ -131,22 +132,21 @@ export const Report = () => {
         console.log("Something went wrong with adding a favorite!");
         return;
       }
-      getRowTopics();
-    } else {
-      const favs = [...favorites];
-      const removed = favs.find(
-        (fav) =>
-          fav.activity.id === topic.activity.id &&
-          fav.issue.id === topic.issue.id
+      setFavorites([...favorites, topic]);
+      const shortenedRecents = removeIssueActivityPair(
+        [...filteredRecents],
+        topic
       );
-      const index = favs.indexOf(removed);
-      favs.splice(index, 1);
-      const saved = await saveFavorites(favs);
+      setFilteredRecents(shortenedRecents);
+    } else {
+      const shortenedFavs = removeIssueActivityPair([...favorites], topic);
+      const saved = await saveFavorites(shortenedFavs);
       if (!saved) {
         console.log("Something went wrong with removing a favorite!");
         return;
       }
-      getRowTopics();
+      setFavorites(shortenedFavs);
+      setFilteredRecents([topic, ...filteredRecents]);
     }
   };
 

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,5 +1,6 @@
 import.meta.hot;
 import React, { useState } from "react";
+import { IssueActivityPair } from "./model";
 
 export const { SNOWPACK_PUBLIC_API_URL } = __SNOWPACK_ENV__;
 
@@ -91,6 +92,21 @@ export const getLongCustomDateString = (day: Date) => {
 
 export const getShortCustomDateString = (day: Date) => {
   return `${day.getDate()}/${day.getMonth() + 1}`;
+};
+
+// Removes an IssueActivityPair object from an array of these objects.
+// Returns the shortened array.
+export const removeIssueActivityPair = (
+  pairs: IssueActivityPair[],
+  item: IssueActivityPair
+): IssueActivityPair[] => {
+  const removed = pairs.find(
+    (pair) =>
+      pair.activity.id === item.activity.id && pair.issue.id === item.issue.id
+  );
+  const index = pairs.indexOf(removed);
+  pairs.splice(index, 1);
+  return pairs;
 };
 
 export const useDebounce = (value, delay) => {


### PR DESCRIPTION
When toggling a favorite, the frontend used to first POST a new array of favorites, and then, after a successful save, GET the newly saved list of favorites from the backend. These GET requests are considered unnecessary and are removed in this PR.
The PR also introduces a small helper function to remove an IssueActivityPair object from an array of these objects. This is useful to modify the local state arrays for favorites and recent issues.

Note: You'll still see a bunch of API calls for time entries due to Rows being rerendered. That will be covered in another refactoring PR and is described in #218.

This PR only fixes #255