### PR TITLE
Refactoring of time entry fetching

### DIFF
--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
-import { IssueActivityPair, TimeEntry, FetchedTimeEntry } from "../model";
-import { getApiEndpoint } from "../utils";
+import React from "react";
+import { IssueActivityPair, TimeEntry } from "../model";
 import { format as formatDate } from "date-fns";
 
 import { Cell } from "./Cell";
@@ -15,7 +14,6 @@ export const Row = ({
   rowEntryIds,
   onCellUpdate,
   onToggleFav,
-  saved,
   isFav,
 }: {
   topic: IssueActivityPair;
@@ -24,7 +22,6 @@ export const Row = ({
   rowEntryIds: number[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
   onToggleFav: (topic: IssueActivityPair) => void;
-  saved: boolean;
   isFav: boolean;
 }) => {
   return (

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -11,7 +11,8 @@ import grip from "../icons/grip-vertical.svg";
 export const Row = ({
   topic,
   days,
-  rowUpdates,
+  rowHours,
+  rowEntryIds,
   onCellUpdate,
   onToggleFav,
   saved,
@@ -19,72 +20,13 @@ export const Row = ({
 }: {
   topic: IssueActivityPair;
   days: Date[];
-  rowUpdates: TimeEntry[];
+  rowHours: number[];
+  rowEntryIds: number[];
   onCellUpdate: (timeEntry: TimeEntry) => void;
   onToggleFav: (topic: IssueActivityPair) => void;
   saved: boolean;
   isFav: boolean;
 }) => {
-  const [rowEntries, setRowEntries] = useState<FetchedTimeEntry[]>([]);
-  const [rowHours, setRowHours] = useState<number[]>([0, 0, 0, 0, 0]);
-  const [rowEntryIds, setRowEntryIds] = useState<number[]>([]);
-
-  let headers = new Headers();
-  headers.set("Accept", "application/json");
-  headers.set("Content-Type", "application/json");
-
-  let params = new URLSearchParams({
-    issue_id: `${topic.issue.id}`,
-    activity_id: `${topic.activity.id}`,
-    from: formatDate(days[0], "yyyy-MM-dd"),
-    to: formatDate(days[4], "yyyy-MM-dd"),
-  });
-
-  const getTimeEntries = async (params: URLSearchParams) => {
-    let entries: { time_entries: FetchedTimeEntry[] } = await getApiEndpoint(
-      `/api/time_entries?${params}`
-    );
-    setRowEntries(entries.time_entries);
-  };
-
-  React.useEffect(() => {
-    getTimeEntries(params);
-  }, [saved, days]);
-
-  const findCurrentHours = (day: Date) => {
-    let hours = 0;
-    let entry: TimeEntry | FetchedTimeEntry = rowUpdates?.find(
-      (entry) => entry.spent_on === formatDate(day, "yyyy-MM-dd")
-    );
-    if (!entry && rowEntries && rowEntries.length > 0) {
-      entry = rowEntries?.find(
-        (entry) => entry.spent_on === formatDate(day, "yyyy-MM-dd")
-      );
-    }
-    if (entry) {
-      hours = entry.hours;
-    }
-    return hours;
-  };
-
-  const findEntryId = (day: Date) => {
-    let id = 0;
-    let entry = rowEntries?.find(
-      (entry) => entry.spent_on === formatDate(day, "yyyy-MM-dd")
-    );
-    if (entry) {
-      id = entry.id;
-    }
-    return id;
-  };
-
-  React.useEffect(() => {
-    const hours = days.map((day) => findCurrentHours(day));
-    setRowHours(hours);
-    const entryIds = days.map((day) => findEntryId(day));
-    setRowEntryIds(entryIds);
-  }, [rowEntries, rowUpdates]);
-
   return (
     <>
       <div className="row">

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -240,15 +240,22 @@ export const Report = () => {
   };
 
   const addIssueActivityHandler = (pair) => {
-    const recentIssue = recentIssues.find((e) => {
+    let recentIssue = filteredRecents.find((e) => {
       return e.issue.id === pair.issue.id && e.activity.id === pair.activity.id;
     });
+    if (!recentIssue) {
+      recentIssue = favorites.find((e) => {
+        return (
+          e.issue.id === pair.issue.id && e.activity.id === pair.activity.id
+        );
+      });
+    }
     if (recentIssue) {
       alert("This issue/activity pair is already added");
       return;
     }
-    const newRecentIssues = [...recentIssues, pair];
-    setRecentIssues(newRecentIssues);
+    const newRecentIssues = [...filteredRecents, pair];
+    setFilteredRecents(newRecentIssues);
   };
 
   const onDragEnd = (result) => {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import { format as formatDate } from "date-fns";
 import { Row } from "../components/Row";
 import { HeaderRow } from "../components/HeaderRow";
 import { QuickAdd } from "../components/QuickAdd";
@@ -15,11 +16,8 @@ import {
   removeIssueActivityPair,
 } from "../utils";
 import { TimeTravel } from "../components/TimeTravel";
-import { format as formatDate } from "date-fns";
 
 export const Report = () => {
-  const navigate = useNavigate();
-
   const [recentIssues, setRecentIssues] = useState<IssueActivityPair[]>([]);
   const [filteredRecents, setFilteredRecents] = useState<IssueActivityPair[]>(
     []
@@ -30,7 +28,8 @@ export const Report = () => {
   const today = new Date();
   const [weekTravelDay, setWeekTravelDay] = useState<Date>(today);
   const [currentWeekArray, setCurrentWeekArray] = useState(getFullWeek(today));
-  let location = useLocation();
+  const navigate = useNavigate();
+  const location = useLocation();
   const user: User = location.state as User;
 
   const getRecentIssuesWithinRange = async () => {
@@ -43,7 +42,6 @@ export const Report = () => {
   };
 
   const getTimeEntries = async (rowTopic: IssueActivityPair, days: Date[]) => {
-    console.log("getting time entries");
     let params = new URLSearchParams({
       issue_id: `${rowTopic.issue.id}`,
       activity_id: `${rowTopic.activity.id}`,
@@ -76,9 +74,7 @@ export const Report = () => {
     const favorites: IssueActivityPair[] = await getApiEndpoint(
       "/api/priority_entries"
     );
-
     const issues = [...recentIssues];
-
     if (!!favorites) {
       let nonFavIssues = [];
       issues.forEach((issue, index) => {
@@ -104,7 +100,6 @@ export const Report = () => {
     getRecentIssuesWithinRange();
   }, [weekTravelDay]);
   React.useEffect(() => {
-    console.log("recent issues", recentIssues);
     getRowData();
   }, [recentIssues]);
 
@@ -259,14 +254,11 @@ export const Report = () => {
     if (!result.destination) {
       return;
     }
-
     const startIndex = result.source.index;
     const endIndex = result.destination.index;
-
     if (startIndex === endIndex) {
       return;
     }
-
     const favs = [...favorites];
     const [moved] = favs.splice(startIndex, 1);
     favs.splice(endIndex, 0, moved);

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -27,7 +27,6 @@ export const Report = () => {
   const [favorites, setFavorites] = useState<IssueActivityPair[]>([]);
   const [timeEntries, setTimeEntries] = useState<FetchedTimeEntry[]>([]);
   const [newTimeEntries, setNewTimeEntries] = useState<TimeEntry[]>([]);
-  const [toggleSave, setToggleSave] = useState(false);
   const today = new Date();
   const [weekTravelDay, setWeekTravelDay] = useState<Date>(today);
   const [currentWeekArray, setCurrentWeekArray] = useState(getFullWeek(today));
@@ -228,10 +227,8 @@ export const Report = () => {
     if (unsavedEntries.length === 0) {
       alert("All changes were saved!");
     }
-    setToggleSave(!toggleSave);
-    setTimeout(() => {
-      setNewTimeEntries(unsavedEntries);
-    }, 1000);
+    await getAllEntries(favorites, filteredRecents);
+    setNewTimeEntries(unsavedEntries);
   };
 
   const handleWeekTravel = (newDay: Date) => {
@@ -369,7 +366,6 @@ export const Report = () => {
                                   days={currentWeekArray}
                                   rowHours={rowHours}
                                   rowEntryIds={rowEntryIds}
-                                  saved={toggleSave}
                                   isFav={true}
                                 />
                               </div>
@@ -403,7 +399,6 @@ export const Report = () => {
                   days={currentWeekArray}
                   rowHours={rowHours}
                   rowEntryIds={rowEntryIds}
-                  saved={toggleSave}
                   isFav={false}
                 />
               </>

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -211,7 +211,7 @@ export const Report = () => {
     return saved;
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (newTimeEntries.length === 0) {
       alert(
         "You haven't added, edited or deleted any time entries yet, so nothing could be saved."
@@ -219,14 +219,12 @@ export const Report = () => {
       return;
     }
     const unsavedEntries = [];
-    newTimeEntries.forEach(async (entry) => {
+    for await (let entry of newTimeEntries) {
       const saved = await reportTime(entry);
       if (!saved) {
         unsavedEntries.push(entry);
-        return;
       }
-      return;
-    });
+    }
     if (unsavedEntries.length === 0) {
       alert("All changes were saved!");
     }


### PR DESCRIPTION
Previously, time entries for all rows were sometimes fetched unnecessarily. This PR removes fetches when
- a row is made a favorite
- a favorite is removed
- favorites are reordered
- a new row is added with quick-add.

With these changes, time entries should only be fetched when
- the page is loaded or reloaded
- the user travels in time
- the user saves changes.
In every of these cases, time entries for all displayed rows are fetched.

To achieve this, all logic from the Row component was moved into Report to control the fetching behavior from there. 
Also, the logic for adding a new row with quick-add, as well as for saving was changed slightly. 
Lastly, some minor cleanup is included. 

This fixes #218. 
Because of the changed saving-logic, it also fixes #302.