### PR TITLE
limit user input in cells

### DIFF
--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -28,18 +28,23 @@ export const Cell = ({
         on {`${date}`}
       </label>
       <input
-        type="number"
+        type="text"
         id={`${topic.issue.id}${topic.activity.id}${formatDate(
           date,
           "yyyy-MM-dd"
         )}`}
-        min={0}
         onChange={(event: any) => {
+          //makes sure that users can only input positive numbers up to 999.99999999...
+          //with an unlimited number of decimals behind the delimiter
+          event.target.value = event.target.value
+            .replace(/[^0-9.]/g, "")
+            .replace(/(^\d{3})\d/g, "$1")
+            .replace(/(\..*?)\..*/g, "$1");
           onCellUpdate({
             id: entryId,
             issue_id: topic.issue.id,
             activity_id: topic.activity.id,
-            hours: +event.target.value,
+            hours: event.target.value,
             comments: "",
             spent_on: formatDate(date, "yyyy-MM-dd"),
           });

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -39,6 +39,7 @@ export const Cell = ({
           event.target.value = event.target.value
             .replace(/[^0-9.]/g, "")
             .replace(/^(\d{3})\d+/, "$1")
+            .replace(/(\.\d{2}).*$/, "$1")
             .replace(/(\..*?)\..*/g, "$1");
           onCellUpdate({
             id: entryId,

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -38,7 +38,7 @@ export const Cell = ({
           //with an unlimited number of decimals behind the delimiter
           event.target.value = event.target.value
             .replace(/[^0-9.]/g, "")
-            .replace(/(^\d{3})\d/g, "$1")
+            .replace(/^(\d{3})\d+/, "$1")
             .replace(/(\..*?)\..*/g, "$1");
           onCellUpdate({
             id: entryId,

--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -40,7 +40,7 @@ export const Cell = ({
             .replace(/[^0-9.]/g, "")
             .replace(/^(\d{3})\d+/, "$1")
             .replace(/(\.\d{2}).*$/, "$1")
-            .replace(/(\..*?)\..*/g, "$1");
+            .replace(/(\..*?)\..*/, "$1");
           onCellUpdate({
             id: entryId,
             issue_id: topic.issue.id,

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -29,7 +29,7 @@ export interface TimeEntry {
   id: number;
   issue_id: number;
   activity_id: number;
-  hours: number;
+  hours: number | string;
   comments: string;
   spent_on: string;
 }

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -232,6 +232,11 @@ export const Report = () => {
     }
     const unsavedEntries = [];
     for await (let entry of newTimeEntries) {
+      if (typeof entry.hours === "string") {
+        entry.hours === ""
+          ? (entry.hours = 0)
+          : (entry.hours = parseFloat(entry.hours));
+      }
       const saved = await reportTime(entry);
       if (!saved) {
         unsavedEntries.push(entry);


### PR DESCRIPTION
This PR makes sure a user can only input positive numbers up to 999.99999999.... with an unlimited number of decimals behind the delimiter. This is mainly done trough three regex in Cell.tsx. They ensure that 
- only numbers 0-9 and the period . are allowed
- not more than 3 numbers before the period are allowed
- no second period is allowed (which would be something like 22.33.44)

Previously, the user's input would immediately be turned into a number by the + operator in this line
`hours: +event.target.value,`
Using that operator gives errors when a user is in the middle of typing and the cell says e.g. "2."
Therefore, the `hours` are now saved as a string in the `newTimeEntries` array that keeps track of changes, and only converted into a float right before save. 

Fixes #298 