### PR TITLE
#352 API calls should not be cached by nginx. 

### DIFF
--- a/backend/api/recentIssuesHandler.go
+++ b/backend/api/recentIssuesHandler.go
@@ -3,9 +3,9 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-
 	"github.com/gofiber/fiber/v2"
+	//log "github.com/sirupsen/logrus"
+	"sort"
 )
 
 // recentIssuesHandler godoc
@@ -75,6 +75,6 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 		return (a.Issue.Id == b.Issue.Id && a.Activity.Id < b.Activity.Id) ||
 			a.Issue.Id > b.Issue.Id
 	})
-
+	//log.Debugf("ENTRIES: %v\n", entries)
 	return c.JSON(entries)
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,11 @@ server {
 
     location /api/ {
         proxy_pass http://urdr:8080/api/;
+        add_header Last-Modified $date_gmt;
+        add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        if_modified_since off;
+        expires off;
+        etag off;
     }
 
     location /swagger/ {


### PR DESCRIPTION
Disabling caching for all calls to location /api/ to avoid use of cached recent_issues.
