### PR TITLE
handle removed or reverted, unsaved changes

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -32,7 +32,6 @@ export const Report = () => {
   const [newTimeEntries, setNewTimeEntries] = useState<TimeEntry[]>([]);
   const today = new Date();
   const [weekTravelDay, setWeekTravelDay] = useState<Date>(today);
-  const [showUnsavedMessage, setShowUnsavedMessage] = useState<boolean>(false);
   const [currentWeekArray, setCurrentWeekArray] = useState(getFullWeek(today));
   const context = React.useContext(AuthContext);
 
@@ -127,13 +126,12 @@ export const Report = () => {
 
   React.useEffect(() => {
     window.removeEventListener("beforeunload", beforeUnloadHandler, true);
-    if (showUnsavedMessage) {
+    if (newTimeEntries.length > 0) {
       window.addEventListener("beforeunload", beforeUnloadHandler, true);
     }
-  }, [showUnsavedMessage]);
+  }, [newTimeEntries]);
 
   const handleCellUpdate = (timeEntry: TimeEntry): void => {
-    setShowUnsavedMessage(true);
     const entries = [...newTimeEntries];
     //check if there is a new entry for same cell
     const existingNewEntry = entries.find(
@@ -310,7 +308,6 @@ export const Report = () => {
     }
     await getAllEntries(favorites, filteredRecents);
     setNewTimeEntries(unsavedEntries);
-    setShowUnsavedMessage(false);
   };
 
   const handleWeekTravel = (newDay: Date) => {
@@ -506,7 +503,7 @@ export const Report = () => {
             })}
         </section>
         <section className="save-button-container">
-          {showUnsavedMessage && (
+          {newTimeEntries.length > 0 && (
             <div class="unsaved-alert-p">
               <p role="status">⚠ You have unsaved changes</p>
             </div>


### PR DESCRIPTION
This PR fixes #299, see details of the bug description there: https://app.zenhub.com/workspaces/aspebodaklungan-60507bca37b5030019f0c5a4/issues/nbisweden/urdr/299  
In short, there used to be an inconsistency in how changes in cells were handled. Now, everything should be treated as it's supposed to. 
With this, the condition for showing user feedback could be simplified as well, we get rid of a state variable. 

Note: GitHub marks a lot as changed that in fact has not changed, I think due to white spaces. I haven't changed anything from line 311 and downwards except line 506: ` {newTimeEntries.length > 0 && (`