### PR TITLE
Link issues to Redmine

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,7 +46,7 @@ func Setup() error {
 	Config.App.Port = getEnv("BACKEND_PORT", "8080")
 	Config.App.SessionDBPath = getEnv("SESSION_DB_PATH", "./session.db")
 
-	Config.Redmine.URL = getEnv("REDMINE_URL", "http://host.docker.internal:3000")
+	Config.Redmine.URL = getEnv("SNOWPACK_PUBLIC_REDMINE_URL", "http://host.docker.internal:3000")
 
 	Config.Database.Path = getEnv("BACKEND_DB_PATH", "./database.db")
 

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -8,6 +8,7 @@ import star from "../icons/star.svg";
 import grip from "../icons/grip-vertical.svg";
 import eye from "../icons/eye-slash.svg";
 import { dateFormat } from "../utils";
+import { SNOWPACK_PUBLIC_REDMINE_URL } from "../utils";
 
 export const Row = ({
   topic,
@@ -40,7 +41,13 @@ export const Row = ({
         </div>
         <div className="col-4 ">
           <div className="issue-label">
-            <p className="issue-label-text">{`# ${topic.issue.id}`}</p>
+            <p className="issue-label-text">
+              <a
+                href={
+                  `${SNOWPACK_PUBLIC_REDMINE_URL}` + `/issues/${topic.issue.id}`
+                }
+              >{`# ${topic.issue.id}`}</a>
+            </p>
             <p className="issue-label-text">
               {topic.custom_name
                 ? `${topic.custom_name}`

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -2,6 +2,7 @@ import.meta.hot;
 import React, { useState } from "react";
 import { IssueActivityPair } from "./model";
 export const { SNOWPACK_PUBLIC_API_URL } = __SNOWPACK_ENV__;
+export const { SNOWPACK_PUBLIC_REDMINE_URL } = __SNOWPACK_ENV__;
 
 export let headers = new Headers();
 headers.set("Accept", "application/json");

--- a/urdr.env.default
+++ b/urdr.env.default
@@ -1,6 +1,6 @@
 BACKEND_DB_PATH="./database.db"
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8080
-REDMINE_URL="http://host.docker.internal:3000"
+SNOWPACK_PUBLIC_REDMINE_URL="http://host.docker.internal:3000"
 SESSION_DB_PATH="./session.db"
 SNOWPACK_PUBLIC_API_URL="http://localhost:4567"


### PR DESCRIPTION
Requires changing variable name in urdr.env so that the Redmine URL can be picked up by Snowpack. Fixes #344 