### PR TITLE
In the quick add, moving the feedback icon to appear inside the input

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -307,8 +307,8 @@ input[type="number"] {
 }
 
 .validation-icon {
-  width: 3%;
-  padding-left: 0;
+  width: 3.5rem;
+  margin-left: -2.8rem;
 }
 
 .hiden {


### PR DESCRIPTION
So that it does not look like a button, we had some user feedback about it. 