### PR TITLE
Must use different URLs to Redmine for frontende and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ named `redmine_db.dump`, and it should be placed in that repository's
 
 In the top-most directory of the `urdr` repository, create the
 file `urdr.env`, using `urdr.env.default` as the template. If you
-are on Linux, you need to set the variable `REDMINE_URL` to the
+are on Linux, you need to set the variables `REDMINE_URL` and
+`SNOWPACK_PUBLIC_REDMINE_URL` to the
 value `"http://172.17.0.1:3000"`. The `SNOWPACK_PUBLIC_API_URL`
 variable should be set to the URL from which the service is publically
 accessible, e.g. `"http://localhost:4567"` during development.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,7 +46,7 @@ func Setup() error {
 	Config.App.Port = getEnv("BACKEND_PORT", "8080")
 	Config.App.SessionDBPath = getEnv("SESSION_DB_PATH", "./session.db")
 
-	Config.Redmine.URL = getEnv("SNOWPACK_PUBLIC_REDMINE_URL", "http://host.docker.internal:3000")
+	Config.Redmine.URL = getEnv("REDMINE_URL", "http://host.docker.internal:3000")
 
 	Config.Database.Path = getEnv("BACKEND_DB_PATH", "./database.db")
 

--- a/urdr.env.default
+++ b/urdr.env.default
@@ -1,6 +1,7 @@
 BACKEND_DB_PATH="./database.db"
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8080
-SNOWPACK_PUBLIC_REDMINE_URL="http://host.docker.internal:3000"
+REDMINE_URL="http://host.docker.internal:3000"
+SNOWPACK_PUBLIC_REDMINE_URL="https://urdr-test-redmine.nbis.se/"
 SESSION_DB_PATH="./session.db"
 SNOWPACK_PUBLIC_API_URL="http://localhost:4567"

--- a/urdr.env.default
+++ b/urdr.env.default
@@ -2,6 +2,6 @@ BACKEND_DB_PATH="./database.db"
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8080
 REDMINE_URL="http://host.docker.internal:3000"
-SNOWPACK_PUBLIC_REDMINE_URL="https://urdr-test-redmine.nbis.se/"
+SNOWPACK_PUBLIC_REDMINE_URL="http://host.docker.internal:3000"
 SESSION_DB_PATH="./session.db"
 SNOWPACK_PUBLIC_API_URL="http://localhost:4567"


### PR DESCRIPTION
In production, backend and frontend need different URLs to Redmine, so we must use different variables in the env for that.