### PR TITLE
Feature/searching activities for issue

### DIFF
--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -19,7 +19,6 @@ export const QuickAdd = ({
   const context = React.useContext(AuthContext);
 
   React.useEffect(() => {
-    console.log("searching activities...");
     let endpoint = "/api/activities";
     if (issue) endpoint += "?issue_id=" + issue.id;
     let didCancel = false;

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -21,7 +21,7 @@ export const QuickAdd = ({
   React.useEffect(() => {
     console.log("searching activities...");
     let endpoint = "/api/activities";
-    if (issue) endpoint += "?issue=" + issue;
+    if (issue) endpoint += "?issue=" + issue.id;
     let didCancel = false;
     const loadActivities = async () => {
       let result: { time_entry_activities: IdName[] } = await getApiEndpoint(

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -21,7 +21,7 @@ export const QuickAdd = ({
   React.useEffect(() => {
     console.log("searching activities...");
     let endpoint = "/api/activities";
-    if (issue) endpoint += "?issue=" + issue.id;
+    if (issue) endpoint += "?issue_id=" + issue.id;
     let didCancel = false;
     const loadActivities = async () => {
       let result: { time_entry_activities: IdName[] } = await getApiEndpoint(

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -19,10 +19,13 @@ export const QuickAdd = ({
   const context = React.useContext(AuthContext);
 
   React.useEffect(() => {
+    console.log("searching activities...");
+    let endpoint = "/api/activities";
+    if (issue) endpoint += "?issue=" + issue;
     let didCancel = false;
     const loadActivities = async () => {
       let result: { time_entry_activities: IdName[] } = await getApiEndpoint(
-        "/api/activities",
+        endpoint,
         context
       );
       if (!didCancel && result) {
@@ -35,14 +38,13 @@ export const QuickAdd = ({
     return () => {
       didCancel = true;
     };
-  }, []);
+  }, [issue]);
 
   // Effect for API call
   React.useEffect(
     () => {
       let didCancel = false;
       const searchIssue = async () => {
-        console.log("Searching issue...");
         if (debouncedSearch) {
           const endpoint = `/api/issues?status_id=*&issue_id=${search}`;
           let result: { issues: Issue[] } = await getApiEndpoint(


### PR DESCRIPTION
This is actually Airen's PR, but it seems to have slipped between the chairs, so I'm just putting it in here to get it merged.

This PR makes the frontend call the backend's `/api/activities` endpoint with an `issue_id` parameter when the "Quick add" drop-down menu is populated.

The parameter's value is the valid issue number that the user has entered.

There will be no visible effect in the frontend from applying this PR.

This PR closes #382 and, therefore, also unblocks my work on limiting the number of activities shown.