### PR TITLE
Fix/limit activities

### DIFF
--- a/backend/api/getActivitiesHandler.go
+++ b/backend/api/getActivitiesHandler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/proxy"
+	"github.com/sirupsen/logrus"
 )
 
 // getActivitiesHandler godoc
@@ -22,6 +23,9 @@ func getActivitiesHandler(c *fiber.Ctx) error {
 	if err != nil {
 		redmineIssueId = 0
 	}
+
+	logrus.Debugf("Gtting activities for issue_id=%d\n",
+		redmineIssueId)
 
 	if ok, err := prepareRedmineRequest(c); !ok {
 		return err
@@ -49,6 +53,11 @@ func getActivitiesHandler(c *fiber.Ctx) error {
 	if err := json.Unmarshal(c.Response().Body(), &activitiesResponse); err != nil {
 		c.Response().Reset()
 		return c.SendStatus(fiber.StatusUnprocessableEntity)
+	}
+
+	// Bypass filtering if we don't have a real issue ID.
+	if redmineIssueId == 0 {
+		return c.JSON(activitiesResponse)
 	}
 
 	activities := activitiesResponse.TimeEntryActivities

--- a/backend/api/getActivitiesHandler.go
+++ b/backend/api/getActivitiesHandler.go
@@ -70,7 +70,7 @@ func getActivitiesHandler(c *fiber.Ctx) error {
 	filteredActivities := TimeEntryActivityResponse{}
 
 	for _, activity := range activitiesResponse.TimeEntryActivities {
-		if !db.IsInvalidEntry(redmineIssueId, activity.Id) {
+		if db.IsValidEntry(redmineIssueId, activity.Id) {
 			filteredActivities.TimeEntryActivities =
 				append(filteredActivities.TimeEntryActivities, activity)
 		}

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -67,9 +67,9 @@ func (db *Database) loadAllInvalidEntries() error {
 	return nil
 }
 
-// IsInvalidEntry() will return true if the combination of Redmine issue
+// IsValidEntry() will return false if the combination of Redmine issue
 // ID and Redmine activity ID is invalid.
-func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bool {
+func (db *Database) IsValidEntry(redmineIssueId int, redmineActivityId int) bool {
 	if invalidActivities == nil {
 		if err := db.loadAllInvalidEntries(); err != nil {
 			fmt.Printf("database.loadAllInvalidEntries() failed: %v\n", err)
@@ -78,17 +78,17 @@ func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bo
 	}
 
 	if alwaysInvalidActivities[redmineActivityId] {
-		return true
+		return false
 	}
 
 	for _, i := range invalidActivities[redmineIssueId] {
 		if i == redmineActivityId {
-			return true
+			return false
 		} else if i > redmineActivityId {
 			break
 		}
 
 	}
 
-	return false
+	return true
 }

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -47,3 +47,20 @@ func (db *Database) loadAllInvalidEntries() error {
 
 	return nil
 }
+
+func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bool {
+	if invalidActivities == nil {
+		if err := db.loadAllInvalidEntries(); err != nil {
+			fmt.Printf("database.loadAllInvalidEntries() failed: %v\n", err)
+			return false
+		}
+	}
+
+	for _, i := range invalidActivities[redmineIssueId] {
+		if i == redmineActivityId {
+			return true
+		}
+	}
+
+	return false
+}

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -1,0 +1,49 @@
+package database
+
+import "fmt"
+
+// invalidActivities is a map that maps Redmine issue IDs onto arrays of
+// invalid Redmine activity IDs for that issue ID.
+var invalidActivities map[int][]int
+
+// loadAllInvalidEntries() loads the static list of invalid combinations
+// of Redmine issue IDs and Redmine activity IDs from the backend
+// database into the package-global invalidActivities structure.  This
+// map is later used by IsInvalidEntry().
+func (db *Database) loadAllInvalidEntries() error {
+	selectStmt := `
+		SELECT	redmine_issue_id,
+				redmine_activity_id
+		FROM	invalid_entry`
+
+	stmt, err := db.handle().Prepare(selectStmt)
+	if err != nil {
+		return fmt.Errorf("sql.Prepare() failed: %w", err)
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query()
+	if err != nil {
+		return fmt.Errorf("sql.Query() failed: %w", err)
+	}
+	defer rows.Close()
+
+	invalidActivities = make(map[int][]int)
+
+	for rows.Next() {
+		var redmineIssueId int
+		var redmineActivityId int
+
+		if err := rows.Scan(&redmineIssueId, &redmineActivityId); err != nil {
+			return fmt.Errorf("sql.Scan() failed: %w", err)
+		}
+
+		invalidActivities[redmineIssueId] =
+			append(invalidActivities[redmineIssueId], redmineActivityId)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("sql.Next() failed: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -2,12 +2,11 @@ package database
 
 import (
 	"fmt"
-
-	"github.com/sirupsen/logrus"
 )
 
-// invalidActivities is a map that maps Redmine issue IDs onto arrays of
-// invalid Redmine activity IDs for that issue ID.
+// invalidActivities is a map that maps a Redmine issue ID to a set of
+// Redmine activity IDs.  If an activity ID is present for an issue ID,
+// then that combination of issue and activity is invalid.
 var invalidActivities map[int][]int
 
 // loadAllInvalidEntries() loads the static list of invalid combinations
@@ -16,11 +15,13 @@ var invalidActivities map[int][]int
 // map is later used by IsInvalidEntry().
 func (db *Database) loadAllInvalidEntries() error {
 	selectStmt := `
-		SELECT	redmine_issue_id,
-				redmine_activity_id
-		FROM	invalid_entry
+		SELECT
+			redmine_issue_id,
+			redmine_activity_id
+		FROM
+			invalid_entry
 		ORDER BY
-				redmine_issue_id, redmine_activity_id`
+			redmine_issue_id, redmine_activity_id`
 
 	stmt, err := db.handle().Prepare(selectStmt)
 	if err != nil {

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -67,6 +67,8 @@ func (db *Database) loadAllInvalidEntries() error {
 	return nil
 }
 
+// IsInvalidEntry() will return true if the combination of Redmine issue
+// ID and Redmine activity ID is invalid.
 func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bool {
 	if invalidActivities == nil {
 		if err := db.loadAllInvalidEntries(); err != nil {

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -18,7 +18,9 @@ func (db *Database) loadAllInvalidEntries() error {
 	selectStmt := `
 		SELECT	redmine_issue_id,
 				redmine_activity_id
-		FROM	invalid_entry`
+		FROM	invalid_entry
+		ORDER BY
+				redmine_issue_id, redmine_activity_id`
 
 	stmt, err := db.handle().Prepare(selectStmt)
 	if err != nil {
@@ -43,7 +45,8 @@ func (db *Database) loadAllInvalidEntries() error {
 		}
 
 		invalidActivities[redmineIssueId] =
-			append(invalidActivities[redmineIssueId], redmineActivityId)
+			append(invalidActivities[redmineIssueId],
+				redmineActivityId)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("sql.Next() failed: %w", err)
@@ -53,9 +56,6 @@ func (db *Database) loadAllInvalidEntries() error {
 }
 
 func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bool {
-	logrus.Debugf("Testing issue_id=%d, activity_id=%d\n",
-		redmineIssueId, redmineActivityId)
-
 	if invalidActivities == nil {
 		if err := db.loadAllInvalidEntries(); err != nil {
 			fmt.Printf("database.loadAllInvalidEntries() failed: %v\n", err)
@@ -66,7 +66,10 @@ func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bo
 	for _, i := range invalidActivities[redmineIssueId] {
 		if i == redmineActivityId {
 			return true
+		} else if i > redmineActivityId {
+			break
 		}
+
 	}
 
 	return false

--- a/backend/internal/database/invalidEntry.go
+++ b/backend/internal/database/invalidEntry.go
@@ -1,6 +1,10 @@
 package database
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
 
 // invalidActivities is a map that maps Redmine issue IDs onto arrays of
 // invalid Redmine activity IDs for that issue ID.
@@ -49,6 +53,9 @@ func (db *Database) loadAllInvalidEntries() error {
 }
 
 func (db *Database) IsInvalidEntry(redmineIssueId int, redmineActivityId int) bool {
+	logrus.Debugf("Testing issue_id=%d, activity_id=%d\n",
+		redmineIssueId, redmineActivityId)
+
 	if invalidActivities == nil {
 		if err := db.loadAllInvalidEntries(); err != nil {
 			fmt.Printf("database.loadAllInvalidEntries() failed: %v\n", err)

--- a/backend/internal/database/invalidEntry_test.go
+++ b/backend/internal/database/invalidEntry_test.go
@@ -52,29 +52,37 @@ func TestIsInvalidEntry(t *testing.T) {
 				redmineIssueId:    2000,
 				redmineActivityId: 35,
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "Not invalid issue+activity",
+			name: "Valid issue+activity",
 			args: args{
 				redmineIssueId:    1900,
 				redmineActivityId: 35,
 			},
+			want: true,
+		},
+		{
+			name: "Design activity (never valid)",
+			args: args{
+				redmineIssueId:    1, // Issue ID 1 does not exist in DB
+				redmineActivityId: 8, // Activity ID 8 always invalid
+			},
 			want: false,
 		},
 		{
-			name: "Design activity (always invalid)",
+			name: "Non-design activity on other issue",
 			args: args{
-				redmineIssueId:    1, // NOTE: Issue ID 1 does not exist
-				redmineActivityId: 8,
+				redmineIssueId:    1, // Issue ID 1 does not exist in DB
+				redmineActivityId: 9, // Activity ID 9 is not always invalid
 			},
 			want: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := db.IsInvalidEntry(tt.args.redmineIssueId, tt.args.redmineActivityId); got != tt.want {
-				t.Errorf("Database.IsInvalidEntry() = %v, want %v", got, tt.want)
+			if got := db.IsValidEntry(tt.args.redmineIssueId, tt.args.redmineActivityId); got != tt.want {
+				t.Errorf("Database.IsValidEntry() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/backend/internal/database/invalidEntry_test.go
+++ b/backend/internal/database/invalidEntry_test.go
@@ -1,0 +1,81 @@
+package database_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"urdr-api/internal/config"
+	"urdr-api/internal/database"
+)
+
+func TestIsInvalidEntry(t *testing.T) {
+	db, err := database.New(config.Config.Database.Path)
+	if err != nil {
+		t.Fatalf("database.New() returned unexpected error %q", err)
+	}
+
+	// Insert test data.
+	insertStmt := `
+	INSERT INTO invalid_entry (redmine_issue_id, redmine_activity_id)
+	VALUES
+		(0,8),
+		(1900,8), (1900,14), (1900,20),
+                (2000,8), (2000,9), (2000,10), (2000,11), (2000,12),
+                (2000,14), (2000,19), (2000,20), (2000,34), (2000,35),
+                (2000,104);
+	`
+	if handle, err := sql.Open("sqlite3",
+		fmt.Sprintf("%s?%s&%s",
+			config.Config.Database.Path,
+			"_auto_vacuum=FULL",
+			"_foreign_keys=true",
+		)); err != nil {
+		t.Fatal("Failed to open test database")
+	} else if _, err := handle.Exec(insertStmt); err != nil {
+		t.Fatal("Failed to insert test data")
+	}
+
+	// Set up and run tests.
+
+	type args struct {
+		redmineIssueId    int
+		redmineActivityId int
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Invalid issue+activity",
+			args: args{
+				redmineIssueId:    2000,
+				redmineActivityId: 35,
+			},
+			want: true,
+		},
+		{
+			name: "Not invalid issue+activity",
+			args: args{
+				redmineIssueId:    1900,
+				redmineActivityId: 35,
+			},
+			want: false,
+		},
+		{
+			name: "Design activity (always invalid)",
+			args: args{
+				redmineIssueId:    1, // NOTE: Issue ID 1 does not exist
+				redmineActivityId: 8,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := db.IsInvalidEntry(tt.args.redmineIssueId, tt.args.redmineActivityId); got != tt.want {
+				t.Errorf("Database.IsInvalidEntry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -1,11 +1,11 @@
--- A proposed relational database schema for Urdr, storing the data that
--- is not kept by Redmine by default but that we need to be persistent
--- between sessions.
+-- The relational database schema for Urdr, storing the data that is not
+-- kept by Redmine by default but that we need to be persistent between
+-- sessions.
 --
 -- We assume that this file is used to initialize a SQLite database.
--- From the command line, this could be done using the following command
--- (which creates the database file "database.db" if it does not already
--- exist):
+-- The Go code does thes automatically, but you may also do so from the
+-- command line, using the following command (which creates the database
+-- file "database.db" if it does not already exist):
 --
 --	sqlite3 database.db <sql/schema.sql
 --
@@ -16,11 +16,6 @@
 -- The "sqlite3" command line utility is part of the "sqlite3" package
 -- on Ubuntu.  The utility is part of the macOS base system and does not
 -- need to be installed separately.
-
--- FIXME:
--- The datatype for the fields whose names start with "redmine_" are
--- currently unknown, so we assume that they are INTEGER in the schema
--- below.
 
 PRAGMA auto_vacuum = FULL;
 PRAGMA foreign_keys = ON;

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -77,3 +77,23 @@ CREATE TABLE priority_entry (
 	UNIQUE (redmine_user_id, redmine_issue_id, redmine_activity_id)
 		ON CONFLICT REPLACE
 );
+
+-- Activity limitations
+-- https://github.com/NBISweden/urdr/issues/338
+--
+-- Not all activities can be used together with every issue.  Some
+-- activities are not "active" for certain projects.  The table stores
+-- the combinations of project IDs and activity IDs that are explicitly
+-- inactivated.  Any combination not listed is active by default.
+-- An activity listed with a zero project ID is deactivated for all
+-- projects (zero is used rather than NULL to avoid issues with the
+-- UNIQUE constraint).
+
+DROP TABLE IF EXISTS deactivated;
+CREATE TABLE deactivated (
+	redmine_project_id INTEGER NOT NULL,
+	redmine_activity_id INTEGER NOT NULL,
+
+	UNIQUE (redmine_project_id, redmine_activity_id)
+		ON CONFLICT REPLACE
+);

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE user_setting (
 		ON DELETE CASCADE
 );
 
--- Priority entries
+-- Priority entries.
 -- https://github.com/NBISweden/urdr/issues/11
 -- https://github.com/NBISweden/urdr/issues/19
 --
@@ -78,22 +78,24 @@ CREATE TABLE priority_entry (
 		ON CONFLICT REPLACE
 );
 
--- Activity limitations
+-- Invalid entries.
 -- https://github.com/NBISweden/urdr/issues/338
 --
 -- Not all activities can be used together with every issue.  Some
--- activities are not "active" for certain projects.  The table stores
--- the combinations of project IDs and activity IDs that are explicitly
--- inactivated.  Any combination not listed is active by default.
--- An activity listed with a zero project ID is deactivated for all
--- projects (zero is used rather than NULL to avoid issues with the
--- UNIQUE constraint).
+-- activities are not "active" for certain projects.  This is
+-- configurable for projects in Redmine, not issues.
+--
+-- This table stores the combinations of issue IDs and activity IDs that
+-- are explicitly inactivated.  Any combination not listed is active by
+-- default.  An activity listed with a zero project ID is deactivated
+-- for all projects (zero is used rather than NULL to avoid issues with
+-- the UNIQUE constraint).
 
-DROP TABLE IF EXISTS deactivated;
-CREATE TABLE deactivated (
-	redmine_project_id INTEGER NOT NULL,
+DROP TABLE IF EXISTS invalid_entry;
+CREATE TABLE invalid_entry (
+	redmine_issue_id INTEGER NOT NULL,
 	redmine_activity_id INTEGER NOT NULL,
 
-	UNIQUE (redmine_project_id, redmine_activity_id)
+	UNIQUE (redmine_issue_id, redmine_activity_id)
 		ON CONFLICT REPLACE
 );

--- a/backend/sql/update-invalid_entry.sh
+++ b/backend/sql/update-invalid_entry.sh
@@ -38,14 +38,22 @@ fi
 	sqlite3 "$2" '.import /dev/stdin invalid_entry'
 } <<'END_COPY'
 COPY (
-	SELECT DISTINCT
-		i.id, e.parent_id 
-	FROM	issues AS i 
-	JOIN	enumerations AS e USING (project_id) 
-	WHERE	e.type = 'TimeEntryActivity' 
-	AND NOT	e.active 
-	ORDER BY
-		i.id, e.parent_id
+	(
+		SELECT	0, e.id
+		FROM	enumerations AS e
+		WHERE	e.type = 'TimeEntryActivity'
+		AND	e.name = 'Design'
+		AND	e.project_id IS NULL
+	)
+	UNION
+	(
+		SELECT DISTINCT
+			i.id, e.parent_id
+		FROM	issues AS i
+		JOIN	enumerations AS e USING (project_id)
+		WHERE	e.type = 'TimeEntryActivity'
+		AND NOT	e.active
+	)
 )
 TO	STDOUT
 WITH	csv

--- a/backend/sql/update-invalid_entry.sh
+++ b/backend/sql/update-invalid_entry.sh
@@ -35,7 +35,10 @@ fi
 {
 	docker-compose -f "$1" exec -T -- postgres \
 		psql -U redmine |
-	sqlite3 "$2" '.import /dev/stdin invalid_entry'
+	sqlite3 "$2" \
+		'DELETE FROM invalid_entry' \
+		'.import /dev/stdin invalid_entry' \
+		'VACUUM'
 } <<'END_COPY'
 COPY (
 	(

--- a/backend/sql/update-invalid_entry.sh
+++ b/backend/sql/update-invalid_entry.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# This script updates the "invalid_entry" table in the backend database.
+# It does this by querying the Redmine instance's PostgreSQL database
+# and inserting the values directly into the Urdr database.
+
+# Arguments:
+#
+# 1:	The pathname for the docker-compose.yml file for the ops-redmine
+#	repository.
+#
+# 2:	The pathname to the Urdr database file.  This file is assumed to
+#	have at least the schema loaded from "backend/sql/schema.sql".
+
+unset -v err
+
+if [ ! -f "$1" ] || [ "${1##*/}" != 'docker-compose.yml' ]; then
+	cat >&2 <<-'END_ERROR'
+	ERROR: The first argument is supposed to be a the pathname to
+	       the ops-redmine repository's docker-compose.yml file
+	END_ERROR
+	err=1
+fi
+
+if [ ! -f "$2" ] || [ "${2%.db}" = "$2" ]; then
+	cat >&2 <<-'END_ERROR'
+	ERROR: The second argument is supposed to be the pathname to the
+	       Urdr backend SQLite3 database file.
+	END_ERROR
+	err=1
+fi
+
+[ "${err+set}" = set ] && exit 1
+
+{
+	docker-compose -f "$1" exec -T -- postgres \
+		psql -U redmine |
+	sqlite3 "$2" '.import /dev/stdin invalid_entry'
+} <<'END_COPY'
+COPY (
+	SELECT DISTINCT
+		i.id, e.parent_id 
+	FROM	issues AS i 
+	JOIN	enumerations AS e USING (project_id) 
+	WHERE	e.type = 'TimeEntryActivity' 
+	AND NOT	e.active 
+	ORDER BY
+		i.id, e.parent_id
+)
+TO	STDOUT
+WITH	csv
+	DELIMITER '|'
+END_COPY
+
+echo 'Done.'
+


### PR DESCRIPTION
This PR adds an extra table to the backend database.  This table is created when the database is recreated. Alternatively, one could add the table manually to an existing database by executing the `CREATE TABLE` statement for the `invalid_entry` table at the end of the `backend/sql/schema.sql` file.

The following insert the new table without touching any other data:
```shell
$ sqlite3 backend/database.db <<'END_SQL'
CREATE TABLE invalid_entry (
        redmine_issue_id INTEGER NOT NULL,
        redmine_activity_id INTEGER NOT NULL,

        UNIQUE (redmine_issue_id, redmine_activity_id)
                ON CONFLICT REPLACE
);
END_SQL
```

A script, `backend/sql/update-invalid_entry.sh`, populates this new static table with the invalid activities for each issue by executing an SQL statement directly against Redmine's PostgreSQL database and importing the result into the Urdr backend's database.

The following shows how to run that script to put data into the newly created table:
```shell
$ backend/sql/update-invalid_entry.sh path/to/ops-redmine/docker-compose.yml backend/database.db
```

The PR also modifies the behaviour of the `/api/activities` endpoint by allowing it to take an `issue_id` parameter.  Given a Redmine issue ID as input, the returned list of activities will be limited to those allowed for that issue ID.

<s>I'm waiting for PR #404 to be merged before allowing reviews on this PR, since it depends on it.</s>

<s>Related to issue #338, but does not quite close it as the "Design" activity is not yet filtered out completely.</s>

To test whether the PR works, compare the activities drop-down menu with issue numbers 1900 and 2000 entered in the "Quick add" field.

Closes issue #338 