### PR TITLE
Capture key events for time entry deletion

### DIFF
--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -35,6 +35,15 @@ export const Cell = ({
       spent_on: formatDate(date, dateFormat),
     });
   };
+  const onDeleteCellEntry = (e: any) => {
+    {
+      if (e.key === "Backspace") {
+        onCellChange(e);
+      } else if (e.key === "Delete") {
+        onCellChange(e);
+      }
+    }
+  };
   const onCellChange = (event: any) => {
     //makes sure that users can only input positive numbers up to 999.99999999...
     //with an unlimited number of decimals behind the delimiter
@@ -73,6 +82,7 @@ export const Cell = ({
             "yyyy-MM-dd"
           )}`}
           onChange={onCellChange}
+          onKeyUp={onDeleteCellEntry}
           className="cell"
           defaultValue={hours === 0 ? "" : hours}
         />

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -332,7 +332,6 @@ export const Report = () => {
     })
       .then((response) => {
         if (response.ok) {
-          console.log("Time reported");
           return true;
         } else if (response.status === 401) {
           logout = true;


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #432

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
<!-- Specify what changes have been made and why -->
The onChange listener does not detect ESC and delete key events upon first change. Therefore we use a onKey listener to figure out whether a time entry needs to be deleted.

## Testing
<!-- Please delete options that are not relevant -->
- Follow the instructions of the bug report written by @HenrikeW 


## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
