### PR TITLE
bug fix introduced by the last commit in the footer

### DIFF
--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -108,7 +108,7 @@ export const QuickAdd = ({
 
   return (
     <div className="row">
-      <h2> Quick add:</h2>
+      <h2> Add a new issue</h2>
       <input
         aria-labelledby="input-issue"
         id="input-issue"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,7 +34,8 @@
 body {
   font-family: Lato, sans-serif;
   color: hsl(0deg 0% 15%);
-  margin: 0;
+  margin-bottom: 120px;
+  justify-content: center;
   min-height: calc(100vh - 120px);
   width: 100%;
   height: 100%;
@@ -123,8 +124,7 @@ input[type="number"] {
 
 .main {
   position: relative;
-  margin: 50px 0 100px;
-  padding: 10px;
+  margin: 50px 0;
 }
 
 .footer {
@@ -306,6 +306,7 @@ input[type="number"] {
 
 .save-button {
   margin: 2rem;
+  min-width: 10rem;
   padding: 1rem 1.5rem;
 }
 

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -553,7 +553,7 @@ export const Report = () => {
     <>
       <LoadingOverlay
         active={isLoading}
-        className="loading-overlay"
+        className={isLoading ? "loading-overlay" : ""}
         spinner={
           <ClimbingBoxLoader
             color="hsl(76deg 55% 53%)"


### PR DESCRIPTION
This PR is to fix a bug introduced by the last commit in the previous PR. The change height: 100vh in the loading-overlay class caused the scroll to stop working. Now the class is only set when the spinner is shown, to restore the page scroll

## Related issue(s) and PR(s)
This PR closes #441

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
## Testing
Scroll and it works


## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
