### PR TITLE
Return vacation if time entries don't exist

### DIFF
--- a/backend/api/recentIssuesHandler.go
+++ b/backend/api/recentIssuesHandler.go
@@ -71,7 +71,7 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 			},
 			Activity: Activity{
 				Id:   19,
-				Name: "Absence (Vacation/VAB/Other",
+				Name: "Absence (Vacation/VAB/Other)",
 			},
 		}
 		entries = append(entries, vacationEntry)

--- a/backend/api/recentIssuesHandler.go
+++ b/backend/api/recentIssuesHandler.go
@@ -3,8 +3,9 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gofiber/fiber/v2"
 	"sort"
+
+	"github.com/gofiber/fiber/v2"
 )
 
 // recentIssuesHandler godoc
@@ -59,6 +60,22 @@ func recentIssuesHandler(c *fiber.Ctx) error {
 			seenEntries[entry] = true
 			entries = append(entries, entry)
 		}
+	}
+
+	// Make sure that when there is not any time entry, we send the vacation entry by default
+	if len(entries) == 0 {
+		vacationEntry := Entry{
+			Issue: Issue{
+				Id:      3499,
+				Subject: "NBIS General",
+			},
+			Activity: Activity{
+				Id:   19,
+				Name: "Absence (Vacation/VAB/Other",
+			},
+		}
+		entries = append(entries, vacationEntry)
+		return c.JSON(entries)
 	}
 
 	// Populate the issue subjects.


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #290 
<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
<!-- Specify what changes have been made and why -->
We now return a "Vacation row" if there is no time entries logged by the user.


## Testing
<!-- Please delete options that are not relevant -->
- Delete all time entries from your user
- Log in and force reload

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
