### PR TITLE
Delete www-authenticate header from login response

### DIFF
--- a/backend/api/loginHandler.go
+++ b/backend/api/loginHandler.go
@@ -37,6 +37,8 @@ func loginHandler(c *fiber.Ctx) error {
 	if err := proxy.Do(c, redmineURL); err != nil {
 		return err
 	} else if c.Response().StatusCode() != fiber.StatusOK {
+		// This prevents the browser from displaying the auth popup
+		c.Response().Header.Del("Www-Authenticate")
 		return nil
 	}
 


### PR DESCRIPTION
This makes sure that the basic auth popup is no longer shown by the browser.

## Related issue(s) and PR(s)
This PR closes #475 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- The header that was being used by Chrome to display the auth pop-up has now been dropped from our server's http response.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing
<!-- Please delete options that are not relevant -->
- Attempt to log in with invalid creds on Chrome

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
