### PR TITLE
populate hidden rows with time entries

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -117,19 +117,12 @@ export const Report = () => {
     return null;
   };
 
-  // Retrieve time entries and recent entries
-  const getAllEntries = async (
-    favs: IssueActivityPair[],
-    recents: IssueActivityPair[]
-  ) => {
+  // Retrieve time entries for given rows
+  const getAllEntries = async (rows: IssueActivityPair[]) => {
     let allEntries = [];
-    for await (let fav of favs) {
-      const favEntries = await getTimeEntries(fav, currentWeekArray);
-      allEntries.push(...favEntries);
-    }
-    for await (let recent of recents) {
-      const recentEntries = await getTimeEntries(recent, currentWeekArray);
-      if (recentEntries) allEntries.push(...recentEntries);
+    for await (let row of rows) {
+      const entries = await getTimeEntries(row, currentWeekArray);
+      allEntries.push(...entries);
     }
     setTimeEntries(allEntries);
   };
@@ -178,13 +171,13 @@ export const Report = () => {
         if (!didCancel) {
           const favorites = priorityIssues.filter((issue) => !issue.is_hidden);
           const hidden = priorityIssues.filter((issue) => issue.is_hidden);
-          getAllEntries(favorites, nonPrioIssues);
+          getAllEntries([...favorites, ...hidden, ...nonPrioIssues]);
           setFilteredRecents(nonPrioIssues);
           setFavorites(favorites);
           setHidden(hidden);
         }
       } else if (!didCancel) {
-        getAllEntries([], issues);
+        getAllEntries(issues);
         setFilteredRecents(issues);
       }
     };
@@ -410,7 +403,7 @@ export const Report = () => {
         unsavedEntries.push(entry);
       }
     }
-    await getAllEntries(favorites, filteredRecents);
+    await getAllEntries([...favorites, ...hidden, ...filteredRecents]);
     setNewTimeEntries(unsavedEntries);
     toggleLoadingPage(false);
     if (unsavedEntries.length === 0) {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #491

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- the function `getAllEntries` was changed to accept a single array of IssueActivityPairs (i.e. rows) as an argument
- where it's called, the hidden rows are included in the argument array (previously, the function took two arrays as arguments, which were the recent rows and the favorite rows). The function is called on page load as well as after successful save. 

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing
<!-- Please delete options that are not relevant -->
- go to the report page in a week that has time entries on favorite, recent and hidden rows. You should see all of them.
- make a change in a time entry in a hidden row and save. The sum should be correct both before and after save.
- un-hide the row you've just made a change in. It should move to the recent section together with all its entries.
- to make sure no previous functionality broke, feel free to play around with modifying time entries and moving rows between all three sections.

## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
