### PR TITLE
Rework focus and blur event handlers

### DIFF
--- a/frontend/src/components/Cell.tsx
+++ b/frontend/src/components/Cell.tsx
@@ -51,7 +51,7 @@ export const Cell = ({
   const onEscapeArea = (e: any) => {
     {
       if (e.key === "Escape") {
-        setShowCommentArea(false);
+        onBlurArea();
       }
     }
   };
@@ -97,10 +97,10 @@ export const Cell = ({
             date,
             "yyyy-MM-dd"
           )}`}
-          onChange={onCellChange}
-          onKeyUp={onDeleteCellEntry}
-          onFocus={onFocusRow}
-          onBlur={onBlurRow}
+          onChange={(ev) => onCellChange(ev)}
+          onKeyUp={(ev) => onDeleteCellEntry(ev)}
+          onFocus={() => onFocusRow()}
+          onBlur={() => onBlurRow()}
           className="cell"
           defaultValue={hours === 0 ? "" : hours}
         />
@@ -109,7 +109,7 @@ export const Cell = ({
             className={comments === "" ? "comment comment-unfilled" : "comment"}
             type="button"
             title="Toggle comment area"
-            onFocus={onFocusRow}
+            onFocus={() => onFocusRow()}
             onClick={() => onCommentButtonClick()}
           ></button>
         )}
@@ -119,14 +119,14 @@ export const Cell = ({
             <textarea
               autoFocus
               className="comment-area"
-              onChange={onCommentUpdate}
+              onChange={(ev) => onCommentUpdate(ev)}
               placeholder="Comments"
               name="comments"
               rows={2}
               maxLength={1000}
-              onKeyUp={onEscapeArea}
-              onFocus={onFocusRow}
-              onBlur={onBlurArea}
+              onKeyUp={(ev) => onEscapeArea(ev)}
+              onFocus={() => onFocusRow()}
+              onBlur={() => onBlurArea()}
               defaultValue={areaComments !== null ? areaComments : comments}
             />
             <button

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -117,12 +117,12 @@ export const Row = ({
               )}`}
               topic={topic}
               date={day}
-              onCellUpdate={onCellUpdate}
+              onCellUpdate={(ev) => onCellUpdate(ev)}
               hours={rowHours[i]}
               comments={rowEntries[i] ? rowEntries[i].comments : ""}
               entryId={rowEntries[i] ? rowEntries[i].id : 0}
-              onFocusRow={onFocusRow}
-              onBlurRow={onBlurRow}
+              onFocusRow={() => onFocusRow()}
+              onBlurRow={() => onBlurRow()}
             />
           );
         })}
@@ -134,8 +134,8 @@ export const Row = ({
             className="cell"
             value={getRowSum(topic)}
             readOnly
-            onFocus={onFocusRow}
-            onBlur={onBlurRow}
+            onFocus={() => onFocusRow()}
+            onBlur={() => onBlurRow()}
             tabIndex={-1}
           />
         </div>


### PR DESCRIPTION
The event handlers now use a arrow fn so that the fns do not fire everytime a component rerenders. Also, now only one row may be selected at a time.

## Related issue(s) and PR(s)
This PR closes #523 

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Event handlers are passed via props using arrow funcs
- We call the correct fn upon ESC when closing the comment area

## Testing
<!-- Please delete options that are not relevant -->
- Usual procedure

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
