### PR TITLE
Dev/search click escape

### DIFF
--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -175,14 +175,6 @@ export const QuickAdd = ({
     return src;
   };
 
-  const onEscapeInput = (e: any) => {
-    {
-      if (e.key === "Escape") {
-        setIsAutoCompleteVisible(false);
-      }
-    }
-  };
-
   const handleHideAutocomplete = () => {
     setIsAutoCompleteVisible(false);
   };
@@ -208,7 +200,6 @@ export const QuickAdd = ({
           className={getSearchClasses()}
           type="text"
           min={0}
-          onKeyUp={(e) => onEscapeInput(e)}
           onChange={(e) => {
             setSearch({ ...search, text: e.target.value });
             setIssue(null);

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { IdName, Issue, IssueActivityPair } from "../model";
 import { getApiEndpoint, useDebounce } from "../utils";
 import plus from "../icons/plus.svg";
 import x from "../icons/x.svg";
 import check from "../icons/check.svg";
 import { AuthContext } from "../components/AuthProvider";
-import { PUBLIC_API_URL, headers } from "../utils";
+import { PUBLIC_API_URL, headers, useEscaper } from "../utils";
 import * as ReactDOM from "react-dom";
 
 export const QuickAdd = ({
@@ -183,6 +183,13 @@ export const QuickAdd = ({
     }
   };
 
+  const handleHideAutocomplete = () => {
+    setIsAutoCompleteVisible(false);
+  };
+
+  const wrapperRef = useRef(null);
+  useEscaper(wrapperRef, handleHideAutocomplete);
+
   return (
     <div>
       <h2> Add a new row</h2>
@@ -237,7 +244,7 @@ export const QuickAdd = ({
         </button>
       </div>
       {search.suggestions.length > 0 && isAutoCompleteVisible && (
-        <ul className="col-8 autocomplete-container">
+        <ul className="col-8 autocomplete-container" ref={wrapperRef}>
           {search.suggestions.map((item) => (
             <li key={item.id} className="autocomplete-item">
               <button

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -1,5 +1,10 @@
 import.meta.hot;
-import React, { useState } from "react";
+import React, {
+  useState,
+  useEffect,
+  ElementType,
+  MouseEventHandler,
+} from "react";
 export const PUBLIC_API_URL = process.env.PUBLIC_API_URL;
 export const PUBLIC_REDMINE_URL = process.env.PUBLIC_REDMINE_URL;
 
@@ -131,4 +136,35 @@ export const useViewport = () => {
 
   // Return the width so we can use it in our components
   return { width };
+};
+
+// Hook to escape a certain DOM element by clicking outside of it or pressing Escape
+export const useEscaper = (
+  ref: React.RefObject<HTMLElement>,
+  callback: () => void
+) => {
+  useEffect(() => {
+    // What should happen when clicked outside the element
+    const handleClickOutside = (event: any) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback();
+      }
+    };
+
+    // What should happen when pressed escape
+    const handleEscape = (event: any) => {
+      if (event.key == "Escape") {
+        callback();
+      }
+    };
+
+    // Bind the event listeners
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      // Unbind the event listeners on clean up
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [ref]);
 };


### PR DESCRIPTION
## Related issue(s) and PR(s)
<!-- Include below a description of the changes proposed in the pull request -->
When having started an advanced search it's now possible to close the appearing list of search results by clicking outside of it or pressing Escape. 
(Pressing Escape was possible before, but only as long focus stayed on the input field. If the user continued tabbing, e.g. to scroll through the list of suggestions, it wasn't possible to use the Escape key to close the list. Now it is.)

The hook could be reused with any DOM element and any desired effect.

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- the hook is defined in a reusable way
- it's used in the QuickAdd component

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
