### PR TITLE
Remove unnecessary success toast

### DIFF
--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -117,7 +117,12 @@ export const Row = ({
                   }
                   onFocus={onFocusRow}
                   onBlur={() => {
-                    onFavNameSave();
+                    if (
+                      topic.custom_name !==
+                      topic.issue.subject + " - " + topic.activity.name
+                    ) {
+                      onFavNameSave();
+                    }
                     onBlurRow();
                   }}
                   onChange={(ev) => {

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -19,6 +19,7 @@ export const Row = ({
   onCellUpdate,
   onToggleFav,
   onFavNameUpdate,
+  onFavNameSave,
   onToggleHide,
   getRowSum,
   isFav,
@@ -31,6 +32,7 @@ export const Row = ({
   onCellUpdate: (timeEntry: TimeEntry) => void;
   onToggleFav: (topic: IssueActivityPair) => void;
   onFavNameUpdate: (topic: IssueActivityPair, custom_name: string) => void;
+  onFavNameSave: () => void;
   getRowSum: (pair: IssueActivityPair) => number;
   onToggleHide?: (topic: IssueActivityPair) => void;
   isFav?: boolean;
@@ -115,6 +117,7 @@ export const Row = ({
                   }
                   onFocus={onFocusRow}
                   onBlur={() => {
+                    onFavNameSave();
                     onBlurRow();
                   }}
                   onChange={(ev) => {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -158,7 +158,7 @@ export const Report = () => {
       );
       const issues = [...recentIssues];
       if (!!priorityIssues) {
-        let nonPrioIssues = [];
+        let nonPrioIssues: IssueActivityPair[] = [];
         issues.forEach((issue) => {
           let match = priorityIssues.find(
             (fav) =>
@@ -528,7 +528,7 @@ export const Report = () => {
   and, if there are none, for entries from the database for the respective cell.
   */
   const findRowHours = (rowTopic: IssueActivityPair) => {
-    let rowHours = [];
+    let rowHours: number[] = [];
     currentWeekArray.map((day) => {
       let hours: number = null;
       let entry: TimeEntry | FetchedTimeEntry = newTimeEntries?.find(
@@ -560,7 +560,7 @@ export const Report = () => {
   If there is no entry in the database, id is 0.
   */
   const findRowEntries = (rowTopic: IssueActivityPair, days: Date[]) => {
-    let entries = [];
+    let entries: FetchedTimeEntry[] = [];
     days.map((day) => {
       let entry = timeEntries?.find(
         (entry) =>
@@ -724,6 +724,7 @@ export const Report = () => {
                     topic={recentIssue}
                     onCellUpdate={handleCellUpdate}
                     onToggleFav={handleToggleFav}
+                    onFavNameUpdate={handleFavNameUpdate}
                     onToggleHide={toggleHide}
                     days={currentWeekArray}
                     rowHours={findRowHours(recentIssue)}
@@ -754,6 +755,7 @@ export const Report = () => {
                       topic={hiddenIssue}
                       onCellUpdate={handleCellUpdate}
                       onToggleFav={handleToggleFav}
+                      onFavNameUpdate={handleFavNameUpdate}
                       onToggleHide={toggleHide}
                       days={currentWeekArray}
                       rowHours={findRowHours(hiddenIssue)}

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -59,7 +59,6 @@ export const Report = () => {
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [changedFavNames, setChangedFavNames] = useState<number[]>([]);
   const context = React.useContext(AuthContext);
   const urlparams = useParams();
 
@@ -197,12 +196,12 @@ export const Report = () => {
   }, [newTimeEntries]);
 
   React.useEffect(() => {
-    if (newTimeEntries.length > 0 || changedFavNames.length > 0) {
+    if (newTimeEntries.length > 0) {
       setShowUnsavedWarning(true);
     } else {
       setShowUnsavedWarning(false);
     }
-  }, [changedFavNames, newTimeEntries]);
+  }, [newTimeEntries]);
 
   const handleCellUpdate = (timeEntry: TimeEntry): void => {
     const entries = [...newTimeEntries];
@@ -316,12 +315,6 @@ export const Report = () => {
       }
       setFavorites(shortenedFavs);
       setFilteredRecents([topic, ...filteredRecents]);
-      // Remove the un-favorited issue from list of changed favs
-      if (changedFavNames.includes(existingFav.issue.id)) {
-        let changedFavs = [...changedFavNames];
-        changedFavs.splice(changedFavs.indexOf(existingFav.issue.id), 1);
-        setChangedFavNames([...changedFavs]);
-      }
     }
   };
 
@@ -340,14 +333,12 @@ export const Report = () => {
       let newFav = { ...existingFav, custom_name };
       favs.splice(favs.indexOf(existingFav), 1, newFav);
       setFavorites(favs);
-
-      // If the favorite has't been updated since the last save,
-      // add it to the list of changed favs for tracking
-      if (!changedFavNames.includes(existingFav.issue.id)) {
-        let changedFavs = [...changedFavNames, existingFav.issue.id];
-        setChangedFavNames(changedFavs);
-      }
     }
+  };
+
+  //Save the fav name
+  const handleFavNameSave = () => {
+    saveFavorites([...favorites, ...hidden]);
   };
 
   // Enable hiding an issue-activity pair from the list of recent issues
@@ -419,31 +410,21 @@ export const Report = () => {
   // Check for ...
   const handleSave = async () => {
     setShowUnsavedWarning(false);
-    if (newTimeEntries.length === 0 && changedFavNames.length === 0) {
+    if (newTimeEntries.length === 0) {
       return;
     }
     toggleLoadingPage(true);
-    let saveFailed = false;
-    if (newTimeEntries.length !== 0) {
-      const unsavedEntries = [];
-      for await (let entry of newTimeEntries) {
-        const saved = await reportTime(entry);
-        if (!saved) {
-          unsavedEntries.push(entry);
-          saveFailed = true;
-        }
-      }
-      await getAllEntries([...favorites, ...hidden, ...filteredRecents]);
-      setNewTimeEntries(unsavedEntries);
-    }
-    if (changedFavNames.length > 0) {
-      const namesSaved = await saveFavorites([...favorites, ...hidden]);
-      if (!namesSaved) {
-        saveFailed = true;
+    const unsavedEntries = [];
+    for await (let entry of newTimeEntries) {
+      const saved = await reportTime(entry);
+      if (!saved) {
+        unsavedEntries.push(entry);
       }
     }
+    await getAllEntries([...favorites, ...hidden, ...filteredRecents]);
+    setNewTimeEntries(unsavedEntries);
     toggleLoadingPage(false);
-    if (!saveFailed) {
+    if (unsavedEntries.length === 0) {
       setToastList([
         ...toastList,
         {
@@ -452,16 +433,8 @@ export const Report = () => {
           message: "All changes saved!",
         },
       ]);
-    } else if (saveFailed) {
+    } else if (unsavedEntries.length > 0) {
       setShowUnsavedWarning(true);
-      setToastList([
-        ...toastList,
-        {
-          type: "warning",
-          timeout: 3000,
-          message: "Not all changes could be saved. Please try again later.",
-        },
-      ]);
     }
   };
 
@@ -697,6 +670,7 @@ export const Report = () => {
                                     onCellUpdate={handleCellUpdate}
                                     onToggleFav={handleToggleFav}
                                     onFavNameUpdate={handleFavNameUpdate}
+                                    onFavNameSave={handleFavNameSave}
                                     days={currentWeekArray}
                                     rowHours={findRowHours(fav)}
                                     rowEntries={rowEntries}
@@ -732,6 +706,7 @@ export const Report = () => {
                     onCellUpdate={handleCellUpdate}
                     onToggleFav={handleToggleFav}
                     onFavNameUpdate={handleFavNameUpdate}
+                    onFavNameSave={handleFavNameSave}
                     onToggleHide={toggleHide}
                     days={currentWeekArray}
                     rowHours={findRowHours(recentIssue)}
@@ -763,6 +738,7 @@ export const Report = () => {
                       onCellUpdate={handleCellUpdate}
                       onToggleFav={handleToggleFav}
                       onFavNameUpdate={handleFavNameUpdate}
+                      onFavNameSave={handleFavNameSave}
                       onToggleHide={toggleHide}
                       days={currentWeekArray}
                       rowHours={findRowHours(hiddenIssue)}


### PR DESCRIPTION
## Related issue(s) and PR(s)
There was a success toast for saved custom names shown every time any changes were saved.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- introduced state variable that tracks if any custom name has been changed
- when pressing "Save changes", an attempt to save custom names is only made if any custom name has changed
- There is only one Toast message for "All changes saved", no specific one about the names. 
- If anything goes wrong in the save with either time entries or custom names, a generic failure message will be shown.

## Testing
<!-- Please delete options that are not relevant -->
- Try to make some changes and save

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
