### PR TITLE
Replace default alerts with Toast

### DIFF
--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { IdName, Issue, IssueActivityPair } from "../model";
+import { IdName, Issue, IssueActivityPair, ToastMsg } from "../model";
 import { getApiEndpoint, useDebounce } from "../utils";
 import plus from "../icons/plus.svg";
 import x from "../icons/x.svg";
@@ -10,8 +10,12 @@ import * as ReactDOM from "react-dom";
 
 export const QuickAdd = ({
   addIssueActivity,
+  toastList,
+  onToastListUpdate,
 }: {
   addIssueActivity: (pair: IssueActivityPair) => void;
+  toastList: ToastMsg[];
+  onToastListUpdate: (newToast: ToastMsg) => void;
 }) => {
   const [activities, setActivities] = useState<IdName[]>([]);
   const [issue, setIssue] = useState<Issue>(null);
@@ -141,7 +145,11 @@ export const QuickAdd = ({
         }
       })
       .catch((error) => {
-        alert(error);
+        onToastListUpdate({
+          type: "warning",
+          timeout: 5000,
+          message: error.message,
+        });
       });
     if (logout) context.setUser(null);
     return foundIssues;
@@ -149,9 +157,12 @@ export const QuickAdd = ({
 
   const handleAdd = (e) => {
     if (issue === null) {
-      alert(
-        "We couldn't add anything. Make sure to type a valid issue number and choose an activity."
-      );
+      onToastListUpdate({
+        type: "warning",
+        timeout: 5000,
+        message:
+          "We couldn't add anything. Make sure to type a valid issue number and choose an activity.",
+      });
     } else {
       const pair: IssueActivityPair = {
         issue: issue,

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -607,6 +607,18 @@ export const Report = () => {
     return pairs;
   };
 
+  // Forwards the option to update the toast list to child components
+  const handleToastListUpdate = (newToast: ToastMsg) => {
+    setToastList([
+      ...toastList,
+      {
+        type: newToast.type,
+        timeout: newToast.timeout,
+        message: newToast.message,
+      },
+    ]);
+  };
+
   if (context.user === null) return <></>;
 
   // Main content
@@ -812,7 +824,11 @@ export const Report = () => {
         <div className="footer">
           <section className="footer-container">
             <div className="col-8">
-              <QuickAdd addIssueActivity={addIssueActivityHandler}></QuickAdd>
+              <QuickAdd
+                addIssueActivity={addIssueActivityHandler}
+                toastList={toastList}
+                onToastListUpdate={handleToastListUpdate}
+              ></QuickAdd>
             </div>
             {toastList.length > 0 && (
               <Toast onCloseToast={handleCloseToast} toastList={toastList} />

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -255,7 +255,14 @@ export const Report = () => {
         }
       })
       .catch((error) => {
-        alert(error);
+        setToastList([
+          ...toastList,
+          {
+            type: "warning",
+            timeout: 5000,
+            message: error.message,
+          },
+        ]);
         const favs = [...favorites];
         setFavorites(favs);
         return false;
@@ -400,11 +407,42 @@ export const Report = () => {
         }
       })
       .catch((error) => {
-        alert(error);
+        setToastList([
+          ...toastList,
+          {
+            type: "warning",
+            timeout: 5000,
+            message: error.message,
+          },
+        ]);
         return false;
       });
     if (logout) context.setUser(null);
     return saved;
+  };
+
+  // Make sure that the custom issue name is saved in the database.
+  const handleCustomNamesSave = async () => {
+    const saved = await saveFavorites([...favorites, ...hidden]);
+    if (!saved) {
+      setToastList([
+        ...toastList,
+        {
+          type: "warning",
+          timeout: 5000,
+          message: "Favourite rows could not be saved. Please try again later.",
+        },
+      ]);
+      return;
+    }
+    setToastList([
+      ...toastList,
+      {
+        type: "success",
+        timeout: 3000,
+        message: "Custom names were saved!",
+      },
+    ]);
   };
 
   // Check for ...
@@ -462,7 +500,14 @@ export const Report = () => {
       });
     }
     if (recentIssue) {
-      alert("This issue/activity pair is already added");
+      setToastList([
+        ...toastList,
+        {
+          type: "warning",
+          timeout: 5000,
+          message: "This issue/activity pair is already added.",
+        },
+      ]);
       return;
     }
     const newRecentIssues = [...filteredRecents, pair];

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -421,30 +421,6 @@ export const Report = () => {
     return saved;
   };
 
-  // Make sure that the custom issue name is saved in the database.
-  const handleCustomNamesSave = async () => {
-    const saved = await saveFavorites([...favorites, ...hidden]);
-    if (!saved) {
-      setToastList([
-        ...toastList,
-        {
-          type: "warning",
-          timeout: 5000,
-          message: "Favourite rows could not be saved. Please try again later.",
-        },
-      ]);
-      return;
-    }
-    setToastList([
-      ...toastList,
-      {
-        type: "success",
-        timeout: 3000,
-        message: "Custom names were saved!",
-      },
-    ]);
-  };
-
   // Check for ...
   const handleSave = async () => {
     setShowUnsavedWarning(false);


### PR DESCRIPTION
## Related issue(s) and PR(s)
There were some places left where we used `alert`. All of them are now replaced with our own Toast, type "warning".

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- because the list of toasts is handled in Report.tsx, a handler function was created and passed on to the child component that needed it (QuickAdd.tsx)
- alerts in QuickAdd and Report were replaced with toasts.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
Just one example.
![image](https://user-images.githubusercontent.com/65461017/182794268-cfea24c5-10e1-4171-9931-626dba58233a.png)


## Testing
<!-- Please delete options that are not relevant -->
Most of the cases are error handling for API requests failing etc, so hard to test. 
The one that can be tested is the one on the screenshot above:
Try to add an issue/activity pair that already is part of your list of recent issues.
You should see the toast (was alert before).

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
