### PR TITLE
remove loading overlay before warning toast appears

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -388,6 +388,7 @@ export const Report = () => {
   // Try to ...
   const reportTime = async (timeEntry: TimeEntry) => {
     let logout = false;
+    toggleLoadingPage(true);
     const saved = await fetch(`${PUBLIC_API_URL}/api/time_entries`, {
       body: JSON.stringify({ time_entry: timeEntry }),
       method: "POST",
@@ -407,6 +408,7 @@ export const Report = () => {
         }
       })
       .catch((error) => {
+        toggleLoadingPage(false);
         setToastList([
           ...toastList,
           {
@@ -427,7 +429,6 @@ export const Report = () => {
     if (newTimeEntries.length === 0) {
       return;
     }
-    toggleLoadingPage(true);
     const unsavedEntries = [];
     for await (let entry of newTimeEntries) {
       const saved = await reportTime(entry);


### PR DESCRIPTION
## Related issue(s) and PR(s)
The toast appearing after a failing time report attempt was covered by the loading overlay.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
The loading overlay is switched off before the warning error is caught

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
![image](https://user-images.githubusercontent.com/65461017/182844217-b561c876-9247-4dfd-99eb-6d48b90e32a4.png)


## Testing
<!-- Please delete options that are not relevant -->
Test a failed report:
* add an invalid combination of issue and activity:
  * choose "Design" in the activity dropdown
  * type any valid issue number and select the issue
  * add it with the plus button
* add a time entry on the newly added row
* press "Save changes"
* you should see the loading overlay for a short while, then it should disappear and a warning toast should be shown

Test a success report: 
* add a time entry to any valid row in your interface
* press "Save changes"
* you should see the same behavior as before: the loading overlay for a short while, then it should disappear and a success toast should be shown


## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
