### PR TITLE
Fetch unlimited time entries

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Login } from "./pages/Login";
 import { Report } from "./pages/Report";
 import { Help } from "./pages/Help";
+import { SpentTime } from "./pages/SpentTime";
 import { AuthProvider } from "./components/AuthProvider";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { getISOWeek } from "date-fns";
@@ -45,6 +46,14 @@ export const App = () => {
                 element={
                   <ProtectedRoute>
                     <Help />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/spent_time"
+                element={
+                  <ProtectedRoute>
+                    <SpentTime />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -106,7 +106,12 @@ export const Report = () => {
   const getAllEntries = async (rows: IssueActivityPair[]) => {
     let allEntries = [];
     for await (let row of rows) {
-      const entries = await getTimeEntries(row, currentWeekArray, context);
+      const entries = await getTimeEntries(
+        row,
+        currentWeekArray[0],
+        currentWeekArray[4],
+        context
+      );
       allEntries.push(...entries);
     }
     setTimeEntries(allEntries);

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -25,6 +25,7 @@ import {
   headers,
   getFullWeek,
   dateFormat,
+  getTimeEntries,
 } from "../utils";
 import { TimeTravel } from "../components/TimeTravel";
 import { AuthContext } from "../components/AuthProvider";
@@ -101,27 +102,11 @@ export const Report = () => {
     setIsLoading(state);
   };
 
-  // Retrieve time entries via api
-  const getTimeEntries = async (rowTopic: IssueActivityPair, days: Date[]) => {
-    let queryparams = new URLSearchParams({
-      issue_id: `${rowTopic.issue.id}`,
-      activity_id: `${rowTopic.activity.id}`,
-      from: formatDate(days[0], dateFormat),
-      to: formatDate(days[4], dateFormat),
-    });
-    let entries: { time_entries: FetchedTimeEntry[] } = await getApiEndpoint(
-      `/api/time_entries?${queryparams}`,
-      context
-    );
-    if (entries) return entries.time_entries;
-    return null;
-  };
-
   // Retrieve time entries for given rows
   const getAllEntries = async (rows: IssueActivityPair[]) => {
     let allEntries = [];
     for await (let row of rows) {
-      const entries = await getTimeEntries(row, currentWeekArray);
+      const entries = await getTimeEntries(row, currentWeekArray, context);
       allEntries.push(...entries);
     }
     setTimeEntries(allEntries);

--- a/frontend/src/pages/SpentTime.tsx
+++ b/frontend/src/pages/SpentTime.tsx
@@ -14,7 +14,8 @@ export const SpentTime = () => {
   const getHoursPerActivity = async () => {
     const timeEntries = await getTimeEntries(
       undefined,
-      [new Date(2019, 6, 5, 10, 33, 30), new Date()],
+      new Date(2019, 6, 5, 10, 33, 30),
+      new Date(),
       context
     );
     let activityHours = {};

--- a/frontend/src/pages/SpentTime.tsx
+++ b/frontend/src/pages/SpentTime.tsx
@@ -1,0 +1,44 @@
+import "../index.css";
+import React, { useState } from "react";
+import { AuthContext } from "../components/AuthProvider";
+import { getTimeEntries } from "../utils";
+import { FetchedTimeEntry } from "model";
+
+export const SpentTime = () => {
+  const [spentTime, setSpentTime] = useState<{}>({});
+
+  React.useEffect(() => {
+    getHoursPerActivity();
+  }, []);
+
+  const getHoursPerActivity = async () => {
+    const timeEntries = await getTimeEntries(
+      undefined,
+      [new Date(2019, 6, 5, 10, 33, 30), new Date()],
+      context
+    );
+    let activityHours = {};
+    timeEntries.map((entry: FetchedTimeEntry) => {
+      activityHours[entry.activity.name]
+        ? (activityHours[entry.activity.name] += entry.hours)
+        : (activityHours[entry.activity.name] = 0);
+      if (activityHours[entry.activity.name] === 0) {
+        activityHours[entry.activity.name] += entry.hours;
+      }
+    });
+    setSpentTime(activityHours);
+  };
+
+  const context = React.useContext(AuthContext);
+
+  return (
+    <>
+      <header>
+        <h1>Spent time</h1>
+      </header>
+      <main>
+        <p>{JSON.stringify(spentTime)}</p>
+      </main>
+    </>
+  );
+};

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -175,7 +175,8 @@ export const useEscaper = (
 // Retrieve time entries via api
 export const getTimeEntries = async (
   issueActivityc: IssueActivityPair,
-  days: Date[],
+  from_date: Date,
+  to_date: Date,
   context: any
 ) => {
   // The ofset param is used to get all time_entries
@@ -185,8 +186,8 @@ export const getTimeEntries = async (
   let queryparams = new URLSearchParams({
     issue_id: issueActivityc ? `${issueActivityc.issue.id}` : "",
     activity_id: issueActivityc ? `${issueActivityc.activity.id}` : "",
-    from: formatDate(days[0], dateFormat),
-    to: formatDate(days[4] ? days[4] : days[1], dateFormat),
+    from: formatDate(from_date, dateFormat),
+    to: formatDate(to_date, dateFormat),
     offset: `${offset}`,
     limit: "100",
   });


### PR DESCRIPTION
Now we can fetch as many time entries as wanted, without limits.

## Related issue(s) and PR(s)
This PR closes #567

<!-- Include below a description of the changes proposed in the pull request -->

## Testing
<!-- Please delete options that are not relevant -->
- Navigate to /spent_time
