### PR TITLE
use current year for bar chart

### DIFF
--- a/frontend/src/components/BarChart.tsx
+++ b/frontend/src/components/BarChart.tsx
@@ -8,8 +8,7 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
   const [total, setTotal] = useState<number>(0);
   const context = useContext(AuthContext);
   const today = new Date();
-  const oneYearAgo = new Date();
-  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+  const startDate = new Date(`January 1, ${today.getFullYear()}`);
 
   useEffect(() => {
     // Whenever the user has saved changes we want to fetch the year's time entries
@@ -24,7 +23,7 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
   const getHoursPerActivity = async () => {
     const timeEntries = await getTimeEntries(
       undefined,
-      oneYearAgo,
+      startDate,
       today,
       context
     );


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #594 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
instead of looking 12 months back from today to get the range for the time log overview, we set January 1st in the current year as a start date for the data fetch.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing
<!-- Please delete options that are not relevant -->
-go to the report page and check the API requests in the dev tools
- The request fetching time entries for a given time frame should have 2022-01-01 as start date and today's date as end date. It should look something like this:
![image](https://user-images.githubusercontent.com/65461017/187217507-3f08e599-5c30-4825-b216-b1666b803379.png)


## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [ ] I have made an effort making the commit history understandable
- [ ] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [ ] My changes generate no new warnings
