### PR TITLE
Fix/add vacation link

### DIFF
--- a/frontend/src/components/HeaderUser.tsx
+++ b/frontend/src/components/HeaderUser.tsx
@@ -14,15 +14,18 @@ export const HeaderUser = ({ username }: { username: string }) => {
     <nav className="nav-wrapper">
       <div className="nav-user">{username}</div>
       <div className="nav-bar">|</div>
-      <button type="button" className="nav-item" onClick={logout}>
-        Log out
-      </button>
       <a className="nav-item" href="/help">
         Help
       </a>
       <a className="nav-item" href="/report">
         Report time
       </a>
+      <a className="nav-item" href="/vacation">
+        Vacation
+      </a>
+      <button type="button" className="nav-item" onClick={logout}>
+        Log out
+      </button>
     </nav>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -708,7 +708,7 @@ Other button classes are defined further down together with other classes for th
   overflow: hidden;
 }
 
-.help-wrapper .page-wrapper{
+.help-wrapper .page-wrapper {
   background-color: hsl(0deg 0% 97%);
   padding: 0 3rem 3rem;
   position: relative;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -708,13 +708,16 @@ Other button classes are defined further down together with other classes for th
   overflow: hidden;
 }
 
-.help-wrapper .page-wrapper {
+.help-wrapper {
   background-color: hsl(0deg 0% 97%);
   padding: 0 3rem 3rem;
   position: relative;
 }
 
 .page-wrapper {
+  background-color: hsl(0deg 0% 97%);
+  padding: 0 3rem 3rem;
+  position: relative;
   height: 650vh;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -713,8 +713,9 @@ Other button classes are defined further down together with other classes for th
   padding: 0 3rem 3rem;
   position: relative;
 }
-.page-wrapper{
-  height:650vh;
+
+.page-wrapper {
+  height: 650vh;
 }
 
 @media (max-width: 700px) and (orientation: portrait) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -129,7 +129,7 @@ Other button classes are defined further down together with other classes for th
 /* stylelint-enable selector-class-pattern */
 
 .usr-header,
-.help-header {
+.page-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -148,7 +148,7 @@ Other button classes are defined further down together with other classes for th
     width: 200vw;
   }
 
-  .help-header {
+  .page-header {
     width: 200vw;
   }
 }
@@ -708,10 +708,13 @@ Other button classes are defined further down together with other classes for th
   overflow: hidden;
 }
 
-.help-wrapper {
+.help-wrapper .page-wrapper{
   background-color: hsl(0deg 0% 97%);
   padding: 0 3rem 3rem;
   position: relative;
+}
+.page-wrapper{
+  height:650vh;
 }
 
 @media (max-width: 700px) and (orientation: portrait) {

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -47,7 +47,7 @@ export const Help = () => {
   };
   return (
     <>
-      <header className="help-header">
+      <header className="page-header">
         <h1 className="help-title">What is urdr?</h1>
         <HeaderUser username={context.user ? context.user.login : ""} />
       </header>

--- a/frontend/src/pages/VacationPlanner.tsx
+++ b/frontend/src/pages/VacationPlanner.tsx
@@ -22,9 +22,16 @@ import {
   getUsersInGroups,
   getGroups,
 } from "../utils";
-import { eachDayOfInterval, Interval, format as formatDate } from "date-fns";
+import {
+  eachDayOfInterval,
+  Interval,
+  format as formatDate,
+  getISOWeekYear,
+} from "date-fns";
 import LoadingOverlay from "react-loading-overlay-ts";
 import ClimbingBoxLoader from "react-spinners/ClimbingBoxLoader";
+import { TimeTravel } from "../components/TimeTravel";
+import { HeaderUser } from "../components/HeaderUser";
 
 export const VacationPlanner = () => {
   const [startDate, setStartDate] = useState<Date>(undefined);
@@ -301,10 +308,11 @@ export const VacationPlanner = () => {
           ></ClimbingBoxLoader>
         }
       ></LoadingOverlay>
-      <header>
-        <h3>Vacation reporting </h3>
+      <header className="page-header">
+        <h1 className="help-title">Vacation reporting</h1>
+        <HeaderUser username={context.user ? context.user.login : ""} />
       </header>
-      <main>
+      <main className="page-wrapper">
         <div className="vacation-plan-dates-wrapper">
           <div className="vacation-plan-container">
             <label


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #602.

Add a link in the nav bar menu for the vacation page. The nav bar menu is included in the vacation page to be abe to navigate back from vacation planner.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
- New link on nav bar
- Nav bar is included in vacation page

## Testing
Navigate to vacation and back to another part of the menu

## Further comments
The height of the className page-header for main will probably be irrelevant when the page content gets bigger.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
