### PR TITLE
Create reusable tooltip for bar chart

### DIFF
--- a/frontend/src/components/BarChart.tsx
+++ b/frontend/src/components/BarChart.tsx
@@ -125,7 +125,7 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
                     </>
                   }
                 >
-                  <div style={{ width: "100%", overflow: "hidden" }}>
+                  <div className="bar-chart-label">
                     <p>{spentTime[key].name}</p>
                     <p>
                       {spentTime[key].hours}h,{" "}

--- a/frontend/src/components/BarChart.tsx
+++ b/frontend/src/components/BarChart.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext } from "react";
 import { AuthContext } from "../components/AuthProvider";
 import { getTimeEntries } from "../utils";
 import { FetchedTimeEntry } from "../model";
+import { Tooltip } from "./Tooltip";
 
 export const BarChart = ({ loading }: { loading: boolean }) => {
   const [spentTime, setSpentTime] = useState<{
@@ -87,7 +88,7 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
         ) : Object.keys(spentTime).includes("Loading") ? (
           <div className="bar-chart-section">Loading...</div>
         ) : (
-          Object.keys(spentTime).map((key) => {
+          Object.keys(spentTime).map((key, index) => {
             // If the number of hours is so low that the width would be rounded down to 0%,
             // make it a thin slice anyway to show that it's there
             const width =
@@ -103,13 +104,35 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
                   backgroundColor: `${
                     colorScheme[key] ? colorScheme[key] : "hsl(291deg 13% 90%)"
                   }`,
+                  borderRadius: `${
+                    index === 0
+                      ? "4px 0 0 4px"
+                      : index === Object.keys(spentTime).length - 1
+                      ? "0 4px 4px 0"
+                      : "0"
+                  }`,
                 }}
                 className="bar-chart-section"
               >
-                <p>{spentTime[key].name}</p>
-                <p>
-                  {spentTime[key].hours}h, {getPercent(spentTime[key].hours)}%
-                </p>
+                <Tooltip
+                  content={
+                    <>
+                      <p>{spentTime[key].name}</p>
+                      <p>
+                        {spentTime[key].hours}h,{" "}
+                        {getPercent(spentTime[key].hours)}%
+                      </p>
+                    </>
+                  }
+                >
+                  <div style={{ width: "100%", overflow: "hidden" }}>
+                    <p>{spentTime[key].name}</p>
+                    <p>
+                      {spentTime[key].hours}h,{" "}
+                      {getPercent(spentTime[key].hours)}%
+                    </p>
+                  </div>
+                </Tooltip>
               </div>
             );
           })

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -107,7 +107,9 @@ export const Row = ({
               >{`# ${topic.issue.id}`}</a>
             </p>
             {isFav ? (
-              <Tooltip text={`${topic.issue.subject} - ${topic.activity.name}`}>
+              <Tooltip
+                content={`${topic.issue.subject} - ${topic.activity.name}`}
+              >
                 <textarea
                   aria-label={`Custom name for the issue ${topic.issue.id}, ${topic.issue.subject}, on the activity ${topic.activity.name}`}
                   className="issue-textarea"

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -107,7 +107,6 @@ export const Row = ({
               >{`# ${topic.issue.id}`}</a>
             </p>
             {isFav ? (
-              // <div className="issuetooltip">
               <Tooltip text={`${topic.issue.subject} - ${topic.activity.name}`}>
                 <textarea
                   aria-label={`Custom name for the issue ${topic.issue.id}, ${topic.issue.subject}, on the activity ${topic.activity.name}`}
@@ -132,10 +131,6 @@ export const Row = ({
                   }}
                   maxLength={100}
                 />
-                {/* <span className="tooltiptext">
-                  {topic.issue.subject} - {topic.activity.name}
-                </span> */}
-                {/* </div> */}
               </Tooltip>
             ) : (
               <p className="issue-label-text">

--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -10,6 +10,7 @@ import eyeSlash from "../icons/eye-slash.svg";
 import eye from "../icons/eye.svg";
 import { dateFormat } from "../utils";
 import { PUBLIC_REDMINE_URL } from "../utils";
+import { Tooltip } from "./Tooltip";
 
 export const Row = ({
   topic,
@@ -106,7 +107,8 @@ export const Row = ({
               >{`# ${topic.issue.id}`}</a>
             </p>
             {isFav ? (
-              <div className="issuetooltip">
+              // <div className="issuetooltip">
+              <Tooltip text={`${topic.issue.subject} - ${topic.activity.name}`}>
                 <textarea
                   aria-label={`Custom name for the issue ${topic.issue.id}, ${topic.issue.subject}, on the activity ${topic.activity.name}`}
                   className="issue-textarea"
@@ -130,10 +132,11 @@ export const Row = ({
                   }}
                   maxLength={100}
                 />
-                <span className="tooltiptext">
+                {/* <span className="tooltiptext">
                   {topic.issue.subject} - {topic.activity.name}
-                </span>
-              </div>
+                </span> */}
+                {/* </div> */}
+              </Tooltip>
             ) : (
               <p className="issue-label-text">
                 {topic.custom_name

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -10,12 +10,12 @@ export const Tooltip = ({
   const [visible, setVisible] = useState(false);
   return (
     <div
-      className="issuetooltip"
+      className="tooltip-wrapper"
       onMouseEnter={() => setVisible(true)}
       onMouseLeave={() => setVisible(false)}
     >
       {children}
-      {visible && <span className="tooltiptext">{text}</span>}
+      {visible && <span className="tooltip-box">{text}</span>}
     </div>
   );
 };

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,21 @@
+import React, { ReactChild, useState } from "react";
+
+export const Tooltip = ({
+  text,
+  children,
+}: {
+  text: string;
+  children: ReactChild;
+}) => {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div
+      className="issuetooltip"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+    >
+      {children}
+      {visible && <span className="tooltiptext">{text}</span>}
+    </div>
+  );
+};

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,10 +1,10 @@
 import React, { ReactChild, useState } from "react";
 
 export const Tooltip = ({
-  text,
+  content,
   children,
 }: {
-  text: string;
+  content: string | JSX.Element;
   children: ReactChild;
 }) => {
   const [visible, setVisible] = useState(false);
@@ -15,7 +15,7 @@ export const Tooltip = ({
       onMouseLeave={() => setVisible(false)}
     >
       {children}
-      {visible && <span className="tooltip-box">{text}</span>}
+      {visible && <span className="tooltip-box">{content}</span>}
     </div>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -407,7 +407,7 @@ Other button classes are defined further down together with other classes for th
   position: absolute;
   bottom: 125%;
   left: 50%;
-  margin-left: -60px;
+  transform: translateX(-50%);
 }
 
 .tooltip-box::after {
@@ -816,11 +816,9 @@ Other button classes are defined further down together with other classes for th
   display: flex;
   width: 100%;
   border-radius: 4px;
-  /* overflow-x: hidden; */
 }
 
 .bar-chart-section {
-  /* overflow-x: hidden; */
   height: 100%;
   padding-left: 0.3rem;
 }
@@ -829,6 +827,11 @@ Other button classes are defined further down together with other classes for th
   display: block ruby;
   margin: 0;
   font-size: 0.8rem;
+}
+
+.bar-chart-label {
+  width: 100%;
+  overflow: hidden;
 }
 
 .vacation-plan-picker-label {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -392,16 +392,12 @@ Other button classes are defined further down together with other classes for th
   opacity: 1;
 }
 
-.issuetooltip {
+.tooltip-wrapper {
   width: 100%;
   position: relative;
-  display: inline-block;
-  opacity: 1;
-  z-index: 1;
 }
 
-.tooltiptext {
-  /* visibility: hidden; */
+.tooltip-box {
   width: auto;
   height: auto;
   background-color: hsl(0deg 0% 90%);
@@ -414,7 +410,7 @@ Other button classes are defined further down together with other classes for th
   margin-left: -60px;
 }
 
-.tooltiptext::after {
+.tooltip-box::after {
   content: "";
   position: absolute;
   top: 100%;
@@ -424,10 +420,6 @@ Other button classes are defined further down together with other classes for th
   border-style: solid;
   border-color: hsl(0deg 0% 0%) transparent transparent transparent;
 }
-
-/* .issuetooltip:hover .tooltiptext {
-  visibility: visible;
-} */
 
 .dropdown-button {
   margin-right: 1rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -816,16 +816,16 @@ Other button classes are defined further down together with other classes for th
   display: flex;
   width: 100%;
   border-radius: 4px;
-  overflow: hidden;
+  /* overflow-x: hidden; */
 }
 
 .bar-chart-section {
-  overflow: hidden;
+  /* overflow-x: hidden; */
   height: 100%;
   padding-left: 0.3rem;
 }
 
-.bar-chart-section > p {
+.bar-chart-section p {
   display: block ruby;
   margin: 0;
   font-size: 0.8rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -401,7 +401,7 @@ Other button classes are defined further down together with other classes for th
 }
 
 .tooltiptext {
-  visibility: hidden;
+  /* visibility: hidden; */
   width: auto;
   height: auto;
   background-color: hsl(0deg 0% 90%);
@@ -425,9 +425,9 @@ Other button classes are defined further down together with other classes for th
   border-color: hsl(0deg 0% 0%) transparent transparent transparent;
 }
 
-.issuetooltip:hover .tooltiptext {
+/* .issuetooltip:hover .tooltiptext {
   visibility: visible;
-}
+} */
 
 .dropdown-button {
   margin-right: 1rem;

--- a/frontend/src/utils.tsx
+++ b/frontend/src/utils.tsx
@@ -179,7 +179,7 @@ export const getTimeEntries = async (
   from_date: Date,
   to_date: Date,
   context: any,
-  user_id: string
+  user_id?: string
 ) => {
   // The ofset param is used to get all time_entries
   // from the api, as the limit per batch is 100


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #592.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- a reusable Tooltip component was created, based on what was already used on the favorite rows
- the tooltip on the favorite rows was replaced by the new component
- the new component was used to show a tooltip on all sections of the bar chart
- the styling of the bar chart had to be slightly adjusted to make the tooltip work (replacing `overflow: hidden` with another border radius)

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
![image](https://user-images.githubusercontent.com/65461017/187695167-dbdbf87d-2985-499d-bbcf-3b252260dfdd.png)
![image](https://user-images.githubusercontent.com/65461017/187695226-bbd91631-838d-48ca-abe4-c6e63d4c49be.png)


## Testing
<!-- Please delete options that are not relevant -->
- go to the report page and hover over the sections of the bar chart. You should see the tooltip appearing above
- also try to hover over the favorite rows. You should see the same tooltip as before

## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
