### PR TITLE
Prevent bar chart from expanding

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -833,12 +833,12 @@ Other button classes are defined further down together with other classes for th
 .bar-chart-section p {
   margin: 0;
   font-size: 0.8rem;
+  white-space: nowrap;
 }
 
 .bar-chart-label {
   width: 100%;
   overflow: hidden;
-  height: 2.4rem; /* this leaves space for two lines of text */
 }
 
 .vacation-plan-picker-label {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -831,7 +831,6 @@ Other button classes are defined further down together with other classes for th
 }
 
 .bar-chart-section p {
-  display: block ruby;
   margin: 0;
   font-size: 0.8rem;
 }
@@ -839,6 +838,7 @@ Other button classes are defined further down together with other classes for th
 .bar-chart-label {
   width: 100%;
   overflow: hidden;
+  height: 2.4rem; /* this leaves space for two lines of text */
 }
 
 .vacation-plan-picker-label {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #611

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- the CSS property `display: block ruby` was removed because it's not supported in Chrome
- instead the `<p>` tags in the label are prevented from line-wrapping

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing
<!-- Please delete options that are not relevant -->
- Check the bar chart in several browsers, especially Chrome

## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
