### PR TITLE
Use `nginx:1.23.1-alpine` in development too

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - exclude:/home/node/app/node_modules
 
   nginx:
-    image: nginx:latest
+    image: nginx:1.23.1-alpine
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8.0-alpine as build
+FROM node:18.8.0-alpine3.16 as build
 
 USER node
 RUN mkdir /home/node/app


### PR DESCRIPTION
This oversight should have been part of #625, related to #624 (now closed).
