### PR TITLE
Fix/update db script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ file `urdr.env`, using `urdr.env.default` as the template. If you
 are on Linux, you need to set the variables `REDMINE_URL` and
 `PUBLIC_REDMINE_URL` to the
 value `"http://172.17.0.1:3000"`. The `PUBLIC_API_URL`
-variable should be set to the URL from which the service is publically
+variable should be set to the URL from which the service is publicly
 accessible, e.g. `"http://localhost:4567"` during development.
 
 The database used by the Urdr backend containing the Urdr schema and
@@ -49,7 +49,7 @@ sqlite3 backend/database.db <backend/sql/schema.sql
 sqlite3 backend/database.db <backend/sql/setting-defaults.sql
 ```
 
-The database must also contain infromation about invalid issue+activity
+The database must also contain information about invalid issue+activity
 pairs, as well as information about Redmine groups and users.  In
 production, this is information that is updated on a regular basis
 by running the two update script in `backend/sql`.  On a development

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ sqlite3 backend/database.db <backend/sql/schema.sql
 sqlite3 backend/database.db <backend/sql/setting-defaults.sql
 ```
 
+The database must also contain infromation about invalid issue+activity
+pairs, as well as information about Redmine groups and users.  In
+production, this is information that is updated on a regular basis
+by running the two update script in `backend/sql`.  On a development
+system, these scripts may be invoked like so:
+
+```shell
+./backend/sql/update-invalid_entry.sh "$REDMINE_REPO"/docker-compose.yml backend/database.db
+./backend/sql/update-groups.sh        "$REDMINE_REPO"/docker-compose.yml backend/database.db
+```
+
+... where `"$REDMINE_REPO"` is some path to the cloned `ops-redmine`
+repository.  Note that the Redmine `postgres` container is assumed to be
+running when these scripts are called.
+
 The name and location of the database file are configurable by setting
 `BACKEND_DB_PATH` in the `urdr.env` file. The value of that variable is
 a pathname relative to the `backend` directory, and the default value is

--- a/backend/sql/update-groups.sh
+++ b/backend/sql/update-groups.sh
@@ -2,61 +2,75 @@
 
 # This script fetches data about the available Redmine groups and
 # updates the local Urdr database with the group information and the
-# users' group memberships.  Data is fetched using the Redmine REST API.
+# users' group memberships.  It does this by querying the Redmine
+# instance's PostgreSQL database and inserting the values directly into
+# the Urdr database.
 
 # Arguments:
 #
-# 1:	The redmine api key of an admin
-# 2:    The redmine api endpoint
-# 3:    The database.db file path
+# 1:  The pathname for the docker-compose.yml file for the ops-redmine
+#     repository.
+#
+# 2:  The pathname to the Urdr database file.  This file is assumed to
+#     have at least the schema loaded from "backend/sql/schema.sql".
 
-tmp_groups=$(mktemp)
-trap 'rm -rf -- "$tmp_groups"' EXIT
-
-api_key=$1
-redmine_url=$2
-database_path=$3
-
-if [ ! -f "$database_path" ] || [ "${database_path%.db}" = "$database_path" ]
-then
+if [ ! -f "$1" ] || [ "${1##*/}" != 'docker-compose.yml' ]; then
 	cat >&2 <<-'END_ERROR'
-	ERROR: The third argument is supposed to be the pathname to the
-	       Urdr backend SQLite3 database file.
+	ERROR: The first argument is supposed to be a the pathname to
+	       the ops-redmine repository's docker-compose.yml file
 	END_ERROR
-	exit 1
+	err=1
 fi
 
-# Fetch basic group info.
+if [ ! -f "$2" ] || [ "${2%.db}" = "$2" ]; then
+	cat >&2 <<-'END_ERROR'
+	ERROR: The second argument is supposed to be the pathname to the
+	       Urdr backend SQLite3 database file.
+	END_ERROR
+	err=1
+fi
 
-curl --silent --header "X-Redmine-API-Key: $api_key" \
-	"$redmine_url/groups.json" >"$tmp_groups"
+[ "${err+set}" = set ] && exit 1
 
-# Import group IDs and their names into our "group" table.
-
-jq -r '.groups[] | [.id, .name] | @csv' "$tmp_groups" |
-sqlite3 "$database_path" \
-	"DELETE FROM group_info" \
-	'.separator ","' \
-	".import /dev/stdin group_info" \
-	'VACUUM'
-
-# Get users for each group.
-
-set --
-
-jq -r '.groups[].id' "$tmp_groups" |
+# Copy group info.
 {
-	while IFS= read -r group_id; do
-		set -- "$@" "$redmine_url/groups/$group_id.json?include=users"
-	done
+	docker-compose -f "$1" exec -T -- postgres \
+		psql -U redmine |
+	sqlite3 "$2" \
+		'DELETE FROM group_info' \
+		'.import /dev/stdin group_info' \
+		'VACUUM'
+} <<'END_COPY'
+COPY (
+	SELECT	id, lastname
+	FROM	users
+	WHERE	type = 'Group'
+	AND	lastname != 'Anonymous Watchers'
+)
+TO	STDOUT
+WITH	csv
+	DELIMITER '|'
+END_COPY
 
-	curl --silent --header "X-Redmine-API-Key: $api_key" "$@" |
-	jq -r '.group | .id as $gid | .users[] | [ .id, $gid ] | @csv' |
-	sqlite3 "$database_path" \
+# Copy group-user relations.
+{
+	docker-compose -f "$1" exec -T -- postgres \
+		psql -U redmine |
+	sqlite3 "$2" \
 		'DELETE FROM user_group' \
-		'.separator ","' \
 		'.import /dev/stdin user_group' \
 		'VACUUM'
-}
+} <<'END_COPY'
+COPY (
+	SELECT	u.id, g.id
+	FROM	users AS u
+	JOIN	groups_users AS gu ON (gu.user_id = u.id)
+	JOIN	users AS g ON (g.id = gu.group_id)
+	WHERE	g.lastname != 'Anonymous Watchers'
+)
+TO	STDOUT
+WITH	csv
+	DELIMITER '|'
+END_COPY
 
 echo 'Done.'

--- a/backend/sql/update-groups.sh
+++ b/backend/sql/update-groups.sh
@@ -14,10 +14,10 @@
 # 2:  The pathname to the Urdr database file.  This file is assumed to
 #     have at least the schema loaded from "backend/sql/schema.sql".
 
-if [ ! -f "$1" ] || [ "${1##*/}" != 'docker-compose.yml' ]; then
+if [ ! -f "$1" ] || [ "${1%.yml}" = "$1" ]; then
 	cat >&2 <<-'END_ERROR'
 	ERROR: The first argument is supposed to be a the pathname to
-	       the ops-redmine repository's docker-compose.yml file
+	       the ops-redmine repository's docker-compose.yml file.
 	END_ERROR
 	err=1
 fi

--- a/backend/sql/update-invalid_entry.sh
+++ b/backend/sql/update-invalid_entry.sh
@@ -14,10 +14,10 @@
 
 unset -v err
 
-if [ ! -f "$1" ] || [ "${1##*/}" != 'docker-compose.yml' ]; then
+if [ ! -f "$1" ] || [ "${1%.yml}" = "$1" ]; then
 	cat >&2 <<-'END_ERROR'
 	ERROR: The first argument is supposed to be a the pathname to
-	       the ops-redmine repository's docker-compose.yml file
+	       the ops-redmine repository's docker-compose.yml file.
 	END_ERROR
 	err=1
 fi


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #640.

The `backend/sql/update-groups.sh` script was rewritten to use the Redmine database directly rather than accessing it via the REST API.  Although the solution based on using the REST API was _neat_, it did require storing an administrator's API key on the host system, which was awkward.  The new implementation avoids this. We now also properly ignore "Anonymous Watcher" users.

The README was also updated to describe the two database update scripts found in `backend/sql` and how to run these.

**To test this PR**: See the README and run the two update scripts.  After running each script, there should only be a simple `Done.` as output, signalling a successful run.  Running a script several times is not a problem.

## Type of change
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 

## Definition of Done checklist
- [X] I have made an effort making the commit history understandable
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
