### PR TITLE
fix autocomplete in footer

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -351,6 +351,7 @@ Other button classes are defined further down together with other classes for th
   padding: 1rem;
   background-color: hsl(0deg 0% 97%);
   display: flex;
+  align-items: flex-end;
 }
 
 .favorites-container {
@@ -490,7 +491,6 @@ Other button classes are defined further down together with other classes for th
 .quick-add {
   align-items: flex-end;
   display: flex;
-  height: 100%;
 }
 
 .quick-add-input {

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -153,9 +153,9 @@ export const Help = () => {
         <p className="help-info">
           In order to add a new row, you first find an issue by using its id or
           it's subject, and then select an activity, which will be linked to the
-          issue. After selecting your desired issue and clicking on the plus
-          button, a new row will be appended to the bottom of the list of recent
-          rows.
+          issue. After selecting your desired issue and clicking on the "Add
+          row"-button, a new row will be appended to the bottom of the list of
+          recent rows.
         </p>
         <QuickAdd addIssueActivity={() => {}}></QuickAdd>
         <h2 className="help-subtitle">The sum row</h2>


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #648

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- the height property on the `.quick-add`  class was removed
- the `.footer-container` class was modified to prevent the input elements in the footer from moving when the unsaved changes warning is displayed.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing
<!-- Please delete options that are not relevant -->
This bug is about the autocomplete box appearing when you search for an issue as well as the unsaved-changes-warning. Play around with these two in mobile and desktop view and see if everything looks good. 
The warning should appear above the save button when you have unsaved changes. The footer should slightly expand for this, but all the elements within the footer should stay in place. 
When you start searching with free text in the issue input field, the box with suggestions should appear below, moving the input elements above it higher up.

## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [ ] I have made an effort making the commit history understandable
- [ ] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [ ] My changes generate no new warnings
