### PR TITLE
Make it possible to edit existing absence periods

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "./components/AuthProvider";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { getISOWeek } from "date-fns";
 import { ConfirmDialogProvider } from "./components/ConfirmDialogProvider";
+import { EditPeriodDialogProvider } from "./components/EditPeriodDialogProvider";
 
 // Route calls
 // Order of routes is critical.
@@ -23,44 +24,46 @@ export const App = () => {
       <React.StrictMode>
         <BrowserRouter>
           <AuthProvider>
-            <ConfirmDialogProvider>
-              <Routes>
-                <Route path="/login" element={<Login />} />
-                <Route
-                  path="/report/:year/:week"
-                  element={
-                    <ProtectedRoute>
-                      <Report />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/*"
-                  element={
-                    <Navigate
-                      replace
-                      to={`/report/${currentYear}/${currentWeek}`}
-                    />
-                  }
-                />
-                <Route
-                  path="/help"
-                  element={
-                    <ProtectedRoute>
-                      <Help />
-                    </ProtectedRoute>
-                  }
-                />
-                <Route
-                  path="/absence"
-                  element={
-                    <ProtectedRoute>
-                      <AbsencePlanner />
-                    </ProtectedRoute>
-                  }
-                />
-              </Routes>
-            </ConfirmDialogProvider>
+            <EditPeriodDialogProvider>
+              <ConfirmDialogProvider>
+                <Routes>
+                  <Route path="/login" element={<Login />} />
+                  <Route
+                    path="/report/:year/:week"
+                    element={
+                      <ProtectedRoute>
+                        <Report />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/*"
+                    element={
+                      <Navigate
+                        replace
+                        to={`/report/${currentYear}/${currentWeek}`}
+                      />
+                    }
+                  />
+                  <Route
+                    path="/help"
+                    element={
+                      <ProtectedRoute>
+                        <Help />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/absence"
+                    element={
+                      <ProtectedRoute>
+                        <AbsencePlanner />
+                      </ProtectedRoute>
+                    }
+                  />
+                </Routes>
+              </ConfirmDialogProvider>
+            </EditPeriodDialogProvider>
           </AuthProvider>
         </BrowserRouter>
       </React.StrictMode>

--- a/frontend/src/components/EditPeriodDialogProvider.tsx
+++ b/frontend/src/components/EditPeriodDialogProvider.tsx
@@ -1,0 +1,116 @@
+import React, {
+  createContext,
+  useState,
+  useRef,
+  useCallback,
+  useContext,
+} from "react";
+import { ModalDialog } from "./ModalDialog";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import sv from "date-fns/locale/sv";
+import { dateFormat } from "../utils";
+
+const EditPeriodDialog = createContext(null);
+
+export const EditPeriodDialogProvider = ({ children }) => {
+  const [updatedAbsenceStartDate, setUpdatedAbsenceStartDate] =
+    useState<Date>(undefined);
+  const [updatedAbsenceEndDate, setUpdatedAbsenceEndDate] =
+    useState<Date>(undefined);
+  const [state, setState] = useState<{}>({ isOpen: false });
+  const handlerFunction =
+    useRef<
+      (selection: { choice: boolean; startDate: Date; endDate: Date }) => void
+    >();
+
+  const UpdateAbsenceRangesContainer = (): JSX.Element => (
+    <div>
+      <p>Please enter below the new start and end date of your absence.</p>
+      <p>From</p>
+      <DatePicker
+        dateFormat={dateFormat}
+        isClearable={true}
+        selected={updatedAbsenceStartDate ? updatedAbsenceStartDate : undefined}
+        onChange={(date: Date) => {
+          setUpdatedAbsenceStartDate(date);
+        }}
+        showWeekNumbers
+        minDate={new Date()}
+        maxDate={new Date("2030-01-01")}
+        locale={sv}
+        showYearDropdown
+        todayButton="Idag"
+        selectsStart
+        startDate={updatedAbsenceStartDate}
+        endDate={updatedAbsenceEndDate}
+        monthsShown={1}
+      />
+      <p>To</p>
+      <DatePicker
+        dateFormat={dateFormat}
+        isClearable={true}
+        selected={updatedAbsenceEndDate ? updatedAbsenceEndDate : undefined}
+        onChange={(date: Date) => {
+          setUpdatedAbsenceEndDate(date);
+        }}
+        showWeekNumbers
+        minDate={updatedAbsenceStartDate}
+        maxDate={new Date("2030-01-01")}
+        locale={sv}
+        showYearDropdown
+        todayButton="Idag"
+        selectsEnd
+        startDate={updatedAbsenceStartDate}
+        endDate={updatedAbsenceEndDate}
+        monthsShown={1}
+      />
+    </div>
+  );
+
+  const selectDates = useCallback(
+    (forwarded) => {
+      return new Promise((resolve) => {
+        setState({ ...forwarded, isOpen: true });
+        handlerFunction.current = (selection: {
+          choice: boolean;
+          startDate: Date;
+          endDate: Date;
+        }) => {
+          resolve(selection);
+          setState({ isOpen: false });
+        };
+      });
+    },
+    [setState]
+  );
+
+  return (
+    <EditPeriodDialog.Provider value={selectDates}>
+      {children}
+      <ModalDialog
+        {...state}
+        onCancel={() =>
+          handlerFunction.current({
+            choice: false,
+            startDate: updatedAbsenceStartDate,
+            endDate: updatedAbsenceEndDate,
+          })
+        }
+        onConfirm={() =>
+          handlerFunction.current({
+            choice: true,
+            startDate: updatedAbsenceStartDate,
+            endDate: updatedAbsenceEndDate,
+          })
+        }
+      >
+        {UpdateAbsenceRangesContainer()}
+      </ModalDialog>
+    </EditPeriodDialog.Provider>
+  );
+};
+
+export const useSelectDates = () => {
+  return useContext(EditPeriodDialog);
+};


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #654 
<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Added new provider for editing absence period dialogs
- Reused the ModalDialog in the newly created provider
- Make it possible to truly edit time entry ranges

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
![bild](https://user-images.githubusercontent.com/3052170/190604978-13331484-d5c0-4d42-90e9-b89281532cde.png)


## Testing
<!-- Please delete options that are not relevant -->
- Click on the edit button of a absence range in the absence page and update the from and to dates.