### PR TITLE
Change dependabot updates from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "frontend/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "backend/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: "gomod"
     directory: "backend/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       
   - package-ecosystem: "npm"
     directory: "frontend/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "frontend/"
@@ -18,14 +18,14 @@ updates:
   - package-ecosystem: "docker"
     directory: "backend/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "production/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "node/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
This PR changes the scheduling for dependabot from "daily" to "weekly".

This change will reduce the number of dependabot PRs we get, allowing us to focus better on other projects. The change is also prompted by the fact that we don't tend to act _immediately_ on seeing these PRs, and that we sometimes even let these PRs time out (get replaced by newer updated PRs).

In the future, when the project is "done", I propose changing the schedule to "monthly".