### PR TITLE
Use the alpine image rather than the slim image

### DIFF
--- a/frontend/Dockerfile.update-package-lock
+++ b/frontend/Dockerfile.update-package-lock
@@ -1,4 +1,4 @@
-FROM node:19.0.1-slim
+FROM node:19.0.1-alpine3.16
 
 USER node
 


### PR DESCRIPTION
This PR changes the Docker base image in the `frontend` directory so that it is the same as used in the `node` Dockerfile.

## Related issue(s) and PR(s)
This PR closes #692 

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made

Use the image based on Alpine Linux rather than `slim`.  This makes it the same as the image used by the Dockerfile in the `node` subdirectory.