### PR TITLE
Feature/floating alpine version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16
+FROM golang:1.19-alpine
 
 ENV XDG_CACHE_HOME='/tmp/.cache'
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 RUN apk --no-cache add \
-        'curl=~7.83.1' \
-        'gcc=~11.2.1' \
+        'curl=~7' \
+        'gcc=~12' \
         'musl-dev=~1.2.3'; \
     rm -rf /var/cache/apk/*; \
     curl --silent --fail --location \

--- a/frontend/Dockerfile.update-package-lock
+++ b/frontend/Dockerfile.update-package-lock
@@ -1,4 +1,4 @@
-FROM node:19.2.0-alpine3.16
+FROM node:19.2.0-alpine
 
 USER node
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19.2.0-alpine3.16 as build
+FROM node:19.2.0-alpine as build
 
 USER node
 RUN mkdir /home/node/app

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16 as builder
+FROM golang:1.19-alpine as builder
 
 ENV GOPATH=$PWD
 
@@ -14,7 +14,7 @@ RUN apk --no-cache add \
 RUN go build -o ./urdr ./cmd && \
     echo "urdr:x:1001:1001:urdr:/:/sbin/nologin" > passwd
 
-FROM alpine:3.17
+FROM alpine
 
 WORKDIR /app
 

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -14,7 +14,7 @@ RUN apk --no-cache add \
 RUN go build -o ./urdr ./cmd && \
     echo "urdr:x:1001:1001:urdr:/:/sbin/nologin" > passwd
 
-FROM alpine
+FROM alpine:latest
 
 WORKDIR /app
 


### PR DESCRIPTION
Since the functionality of the Urdr images doesn't depend on the version of the underlying Alpine Linux release, we might just as well use a floating (unversioned) `alpine` tag with the images that we base our Docker builds on.