### PR TITLE
Continuation line should not have been continuation line

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -9,7 +9,7 @@ COPY ./ .
 
 RUN apk --no-cache add \
     'gcc=~12' \
-    'musl-dev=~1.2'; \
+    'musl-dev=~1.2'
 
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Fixes a typo that managed to get into the release, breaking the image build.