### PR TITLE
Add the workaround for that weird Docker network bug

### DIFF
--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -21,6 +21,9 @@ services:
     restart: always
     env_file:
       - ./urdr.env
+    networks:
+      - redmine_net
+
   nginx:
     image: ghcr.io/nbisweden/urdr-web:${TAG:-latest}
     container_name: urdr-web
@@ -37,6 +40,12 @@ services:
     ports:
       - 4567:80
     restart: always
+    networks:
+      - redmine_net
 
 volumes:
   exclude: null
+
+networks:
+  redmine_net:
+    external: true


### PR DESCRIPTION
This tiny PR fixes the production Docker compose file by adding the workaround for the weird Docker network bug that we came across some time ago.  The change makes Urdr use a specific pre-existing Docker network.