### PR TITLE
fix: fetch activities from /projects

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -68,7 +68,7 @@ func Setup() *fiber.App {
 
 	app.Get("/api/issues", getIssuesHandler)
 
-	app.Get("/api/activities", getActivitiesHandler)
+	app.Get("/api/activities", getProjectActivitiesHandler)
 
 	app.Get("/api/priority_entries", getPriorityEntriesHandler)
 

--- a/backend/api/getPriorityEntriesHandler.go
+++ b/backend/api/getPriorityEntriesHandler.go
@@ -62,7 +62,7 @@ func getPriorityEntriesHandler(c *fiber.Ctx) error {
 	// Now fetch the activities from Redmine and fill out the
 	// activity names.
 	c.Response().Reset()
-	if err := getActivitiesHandler(c); err != nil {
+	if err := getProjectActivitiesHandler(c); err != nil {
 		// There was some error in the handler.
 		return err
 	} else if c.Response().StatusCode() != fiber.StatusOK {

--- a/backend/api/handlers_test.go
+++ b/backend/api/handlers_test.go
@@ -102,18 +102,19 @@ func Test_Handlers(t *testing.T) {
 
 	createdEntry, _ := json.Marshal(entryResult)
 	fetchedEntries, _ := json.Marshal(entriesResult)
-
-	entryActs := redmine.TimeEntryActivitiesResult{
-		TimeEntryActivities: []redmine.TimeEntryActivity{
-			{
-				Id:        1,
-				Name:      "Test activity",
-				IsDefault: true,
+	projectEntry := redmine.ProjectEntry{
+		Project: redmine.Project{
+			TimeEntryActivities: []redmine.TimeEntryActivity{
+				{
+					Id:        1,
+					Name:      "test activity",
+					IsDefault: true,
+				},
 			},
 		},
 	}
 
-	entryActsResponse, _ := json.Marshal(entryActs)
+	projectActivities, _ := json.Marshal(projectEntry)
 
 	issueAct := []api.PriorityEntry{
 		{
@@ -179,8 +180,8 @@ func Test_Handlers(t *testing.T) {
 			}
 		case "/issues.json":
 			_, err = w.Write(issuesResponse)
-		case "/enumerations/time_entry_activities.json":
-			_, err = w.Write(entryActsResponse)
+		case "/projects/1.json":
+			_, err = w.Write(projectActivities)
 		default:
 			log.Debugf("%s.\n", endpoint)
 			_, err = w.Write(nil)
@@ -315,7 +316,7 @@ func Test_Handlers(t *testing.T) {
 		{
 			name:             "Entry activities",
 			method:           "GET",
-			endpoint:         "/api/activities",
+			endpoint:         "/api/activities?project_id=1&issue_id=1",
 			testRedmine:      fakeRedmine,
 			useSessionHeader: true,
 			statusCode:       fiber.StatusOK,
@@ -323,7 +324,7 @@ func Test_Handlers(t *testing.T) {
 		{
 			name:             "Entry activities 401",
 			method:           "GET",
-			endpoint:         "/api/activities",
+			endpoint:         "/api/activities?project_id=1&issue_id=1",
 			testRedmine:      fakeRedmine,
 			useSessionHeader: false,
 			statusCode:       fiber.StatusUnauthorized,
@@ -331,10 +332,18 @@ func Test_Handlers(t *testing.T) {
 		{
 			name:             "Entry activities 422",
 			method:           "GET",
-			endpoint:         "/api/activities",
+			endpoint:         "/api/activities?project_id=1&issue_id=1",
 			testRedmine:      badRedmine,
 			useSessionHeader: true,
 			statusCode:       fiber.StatusUnprocessableEntity,
+		},
+		{
+			name:             "Entry activities no params",
+			method:           "GET",
+			endpoint:         "/api/activities",
+			testRedmine:      badRedmine,
+			useSessionHeader: true,
+			statusCode:       fiber.StatusOK,
 		},
 		{
 			name:             "priority_entries POST",

--- a/backend/api/postTimeEntriesHandler.go
+++ b/backend/api/postTimeEntriesHandler.go
@@ -73,8 +73,10 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 		log.Errorf("proxy.Do() failed: %v\n", err)
 		return c.SendStatus(fiber.StatusInternalServerError)
 	}
+	log.Debugf("respose from redmine: %s", c.Response().Body())
 
 	if session, err := store.Get(c); err != nil {
+
 		return c.SendStatus(fiber.StatusInternalServerError)
 	} else {
 		// Extend the session's expiry time to a week.

--- a/backend/internal/redmine/models.go
+++ b/backend/internal/redmine/models.go
@@ -75,3 +75,10 @@ type Group struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
 }
+type Project struct {
+	TimeEntryActivities []TimeEntryActivity `json:"time_entry_activities"`
+}
+
+type ProjectEntry struct {
+	Project Project `json:"project"`
+}

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -36,7 +36,7 @@ export const QuickAdd = ({
 
   React.useEffect(() => {
     let endpoint = "/api/activities";
-    if (issue) endpoint += "?issue_id=" + issue.id;
+    if (issue) endpoint += "?project_id=" + (issue.project.id ? issue.project.id : "0") + "&issue_id=" + (issue.id ? issue.id : "0");
     let didCancel = false;
     const loadActivities = async () => {
       let result: { time_entry_activities: IdName[] } = await getApiEndpoint(
@@ -44,8 +44,8 @@ export const QuickAdd = ({
         context
       );
       if (!didCancel && result) {
-        setActivities(result.time_entry_activities);
-        setActivity(activity ? activity : result.time_entry_activities[0]);
+        setActivities(result.time_entry_activities ? result.time_entry_activities : []);
+        setActivity(activity ? activity : Array.isArray(result.time_entry_activities) ? result.time_entry_activities[0] : null);
       }
     };
 

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -45,7 +45,7 @@ export const QuickAdd = ({
       );
       if (!didCancel && result) {
         setActivities(result.time_entry_activities ? result.time_entry_activities : []);
-        setActivity(activity ? activity : Array.isArray(result.time_entry_activities) ? result.time_entry_activities[0] : null);
+        setActivity(activity ? activity : (Array.isArray(result.time_entry_activities) && result.time_entry_activities.length > 0) ? result.time_entry_activities[0] : null);
       }
     };
 

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -24,6 +24,7 @@ export interface IssueActivityPair {
 export interface Issue {
   id: number;
   subject: string;
+  project: IdName;
 }
 
 export interface TimeEntry {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -43,7 +43,12 @@ module.exports = {
     historyApiFallback: true,
     static: './public',
     client: {
-      webSocketURL: 'ws://localhost:4567/ws'
+      webSocketURL: 'ws://localhost:4567/ws',
+      overlay: {
+        errors: true,
+        warnings: false,
+        runtimeErrors: false
+      }
     }
   },
   plugins: [


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #846 
<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->

- Frontend changes to use the updated /api/activities endpoint
- Updated /api/activities to use redmine /projects instead of /enumerations

This way we can get the actual activity entries that are allowed by redmine.

## Testing
<!-- Please delete options that are not relevant -->
- Connect urdr to the production redmine
- Try to report using the Implementation activity to the GDI issue
- Run the unit tests

## Further comments
<!-- Specify questions or related information -->
For more context, read the related issue.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
