### PR TITLE
fix: Make search also return Project info

### DIFF
--- a/backend/api/issueSearchHandler.go
+++ b/backend/api/issueSearchHandler.go
@@ -36,9 +36,10 @@ func issueSearchHandler(c *fiber.Ctx) error {
 
 	searchResponse := struct {
 		Results []struct {
-			Id    int    `json:"id"`
-			Type  string `json:"type"`
-			Title string `json:"title"`
+			Id      int     `json:"id"`
+			Type    string  `json:"type"`
+			Title   string  `json:"title"`
+			Project Project `json:"project"`
 		} `json:"results"`
 	}{}
 
@@ -73,6 +74,7 @@ func issueSearchHandler(c *fiber.Ctx) error {
 			issue := Issue{
 				Id:      issue.Id,
 				Subject: issuesResponse.Issues[0].Subject,
+				Project: issuesResponse.Issues[0].Project,
 			}
 			foundIssues = append(foundIssues, issue)
 		}

--- a/backend/api/models.go
+++ b/backend/api/models.go
@@ -4,9 +4,14 @@ type user struct {
 	Login string `json:"login"`
 }
 
+type Project struct {
+	Id int `json:"id"`
+}
+
 type Issue struct {
-	Id      int    `json:"id"`
-	Subject string `json:"subject"`
+	Id      int     `json:"id"`
+	Subject string  `json:"subject"`
+	Project Project `json:"project"`
 }
 
 type IssueWithTitle struct {

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -126,6 +126,7 @@ export const QuickAdd = ({
       messages: "0",
       // projects: "0" produces weird results.
       open_issues: "1",
+      projects: "1",
     };
 
     const foundIssues: { issues: Issue[] } = await fetch(


### PR DESCRIPTION
This solves the existing bug when you search based on normal text instead of issue ids.

## Related issue(s) and PR(s)
This PR closes #857
<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Make search endpoint also return project info
- Handle new project info accordingly in the urdr proxy

## Testing
<!-- Please delete options that are not relevant -->
- In quick search, search for GDI and select an issue
- Run the unit tests


## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
