### PR TITLE
Remove use of external Docker network

### DIFF
--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     restart: always
     env_file:
       - ./urdr.env
-    networks:
-      - redmine_net
 
   nginx:
     image: ghcr.io/nbisweden/urdr-web:${TAG:-latest}
@@ -40,12 +38,6 @@ services:
     ports:
       - 4567:80
     restart: always
-    networks:
-      - redmine_net
 
 volumes:
   exclude: null
-
-networks:
-  redmine_net:
-    external: true


### PR DESCRIPTION
This corresponds to the live changes made on the 31st of October when a Docker-related networking issue forced us to move the service into an LXC container.  The use of an external Docker network was a hack to cope with an earlier Docker network issue.  That issue was resolved when setting up the service in LXC.
