### PR TITLE
Delete the request body when changing the method to "DELETE"

### DIFF
--- a/backend/api/postTimeEntriesHandler.go
+++ b/backend/api/postTimeEntriesHandler.go
@@ -58,6 +58,7 @@ func postTimeEntriesHandler(c *fiber.Ctx) error {
 		} else {
 			// Delete time entry.
 			method = fiber.MethodDelete
+			c.Request().SetBody([]byte{})
 		}
 	}
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #955 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made

When detecting that a time entry should be _deleted_, the request body is deleted.  This avoids a complaint from any intermediate network proxy from complaining about the request.

## How to test

To test the change, you will have to reproduce the error.  You can do that by setting up a local HAProxy instance between your Urdr instance and Redmine, like this:

0. Possibly, create a temporary empty directory and change into it.
1. Create a HAProxy configuration file, `haproxy.cfg`, containing the following:
   ```
   listen redmine
        bind :80
        mode http
        server localhost 192.168.1.20:3000
   ```

   Change `192.168.1.20:3000` to the Redmine instance that you want to connect to.

2. Start the `haproxy` Docker container running in the background:
   ```
   docker run -d --rm -p 3333:80 --name haproxy -v ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro haproxy:lts-alpine
   ```

3. Later, when you don't need the container any longer, remove it with:
   ```
   docker stop haproxy
   ```

You should then configure Urdr to connect to your HAProxy _instead of_ Redmine. I do this by setting the relevant variables in `urdr.env` to point to the HAProxy container's port 3333 (this is `3333` from `-p 3333:80` on the command line when the HAProxy container was started):
```
REDMINE_URL="http://192.168.1.20:3333"
PUBLIC_REDMINE_URL="http://192.168.1.20:3333"
```
(The IP address `192.168.1.20` is the external IP of my local machine.)

The bug should manifest when you try to remove an existing time entry by setting its hour values to zero in the web UI.  Applying the code changes in this PR should fix the issue and you should be able to remove time entries.