### PR TITLE
Bump gcc version and use Alpine 3.20 base image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18
+FROM golang:1.20-alpine
 
 ENV XDG_CACHE_HOME='/tmp/.cache'
 
@@ -8,7 +8,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 RUN apk --no-cache add \
     'curl=~8' \
-    'gcc=~12' \
+    'gcc=~13' \
     'musl-dev=~1.2'; \
     curl --silent --fail --location \
     'https://raw.githubusercontent.com/cosmtrek/air/v1.44.0/install.sh' | \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM golang:1.23-alpine
 
 ENV XDG_CACHE_HOME='/tmp/.cache'
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.23-alpine3.20
 
 ENV XDG_CACHE_HOME='/tmp/.cache'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 
 services:
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.3.0-alpine as build
+FROM node:20.3.0-alpine AS build
 
 USER node
 RUN mkdir /home/node/app

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go
 COPY ./ .
 
 RUN apk --no-cache add \
-    'gcc=~12' \
+    'gcc=~13' \
     'musl-dev=~1.2'
 
 ENV GOPATH=$PWD

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine3.20 as builder
+FROM golang:1.23-alpine3.20 AS builder
 
 RUN addgroup -S urdr && getent group urdr >/tmp/group
 RUN adduser -S urdr && getent passwd urdr >/tmp/passwd

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine3.20 as builder
 
 RUN addgroup -S urdr && getent group urdr >/tmp/group
 RUN adduser -S urdr && getent passwd urdr >/tmp/passwd

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN addgroup -S urdr && getent group urdr >/tmp/group
 RUN adduser -S urdr && getent passwd urdr >/tmp/passwd

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 
 services:
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #977.

This PR should fix the automatic Docker image builds that are done by Github actions when we push to the `develop` branch. The issue was that the `production` Dockerfile tried to install a too-old version of the `gcc` compiler. This has been resolved, and the `backend` Dockerfile has been amended to use the same `golang` base image.

As suggested by other dependabot PRs, also bump the Go version to 1.23 while we're here.

### To test:

Ensure that `docker compose build` succeeds in both the `production` subdirectory (where it fails without this PR), and in the main directory.