### PR TITLE
Fix Urdr panic when user has starred a closed issue

### DIFF
--- a/backend/api/getPriorityEntriesHandler.go
+++ b/backend/api/getPriorityEntriesHandler.go
@@ -90,7 +90,7 @@ func getPriorityEntriesHandler(c *fiber.Ctx) error {
 func getProjectIdForIssue(c *fiber.Ctx, issueId int) (int, error) {
 	c.Response().Reset()
 	c.Request().URI().SetQueryString(
-		fmt.Sprintf("issue_id=%d", issueId))
+		fmt.Sprintf("issue_id=%d,status_id=*", issueId))
 
 	if err := getIssuesHandler(c); err != nil {
 	} else if c.Response().StatusCode() != fiber.StatusOK {


### PR DESCRIPTION
The `issues.json` Redmine endpoint does not, by default, return data for closed issues.  This means that when a user has starred a Redmine issue that later is _closed_, Urdr can't find any information about it and panics.  The panic is due to accessing the first element from an empty array, which is empty because there was no information from Redmine about the issue, because it was closed.


## Related issue(s) and PR(s)
This PR closes #1002.



## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made

This PR allows us to find the project ID for closed Redmine issues that a user has starred in Urdr.  This is done by adding `status_id=*` as a query parameter to the relevant REST API call.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

## Testing

To test: Star a closed issue (for example 7398) and reload.  You will have problem seeing your favourites.

With the PR, this should work.

## Further comments

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
