### PR TITLE
fix: show empty total hours cells during data load

### DIFF
--- a/frontend/src/components/Row.tsx
+++ b/frontend/src/components/Row.tsx
@@ -34,7 +34,7 @@ export const Row = ({
   onToggleFav: (topic: IssueActivityPair) => void;
   onFavNameUpdate: (topic: IssueActivityPair, custom_name: string) => void;
   onFavNameSave: () => void;
-  getRowSum: (pair: IssueActivityPair) => number;
+  getRowSum: (pair: IssueActivityPair) => string;
   onToggleHide?: (topic: IssueActivityPair) => void;
   isFav?: boolean;
   isHidden?: boolean;

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -63,6 +63,7 @@ export const Report = () => {
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [showTotalHours, setShowTotalHours] = useState(false);
   const context = React.useContext(AuthContext);
   const urlparams = useParams();
   const gitBranch = process.env.GIT_BRANCH;
@@ -121,6 +122,10 @@ export const Report = () => {
       allEntries.push(...entries);
     }
     setTimeEntries(allEntries);
+
+    if (allEntries.length > 0) {
+      setShowTotalHours(true);
+    }
   };
 
   // If weekTravelDay changes, do this...
@@ -447,6 +452,7 @@ export const Report = () => {
   const handleWeekTravel = (newDay: Date) => {
     setWeekTravelDay(newDay);
     setCurrentWeekArray(getFullWeek(newDay));
+    setShowTotalHours(false);
   };
 
   const addIssueActivityHandler = async (pair: IssueActivityPair) => {
@@ -590,12 +596,13 @@ export const Report = () => {
     return count;
   };
 
-  const getRowSum = (pair: IssueActivityPair) => {
+  const getRowSum = (pair: IssueActivityPair): string => {
+    if (!showTotalHours) return "";
     const sum = findRowHours(pair).reduce(
       (previousValue, currentValue) => previousValue + currentValue,
       0
     );
-    return sum;
+    return sum.toString();
   };
 
   // Removes an IssueActivityPair object from an array of these objects.
@@ -796,7 +803,7 @@ export const Report = () => {
                         type="text"
                         id={dateStr}
                         className="cell"
-                        value={getTotalHours(dateStr)}
+                        value={showTotalHours ? getTotalHours(dateStr) : ""}
                         readOnly
                         tabIndex={-1}
                       />
@@ -809,7 +816,7 @@ export const Report = () => {
                     aria-label="total of hours spent during the week"
                     type="text"
                     className="cell"
-                    value={getTotalHoursWeek()}
+                    value={showTotalHours ? getTotalHoursWeek() : ""}
                     readOnly
                     tabIndex={-1}
                   />


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1037.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
<!-- Specify what changes have been made and why -->
* Updated the display logic for total hours cells to remain empty until all time entries are loaded, instead of displaying potentially misleading zero values.

## Testing
<!-- Please delete options that are not relevant -->
- Navigate to the report page and verify that the total hours cells (to the right and at the bottom) are empty while the time entries are being loaded. Once the loading is complete, confirm that the cells display the correct sum of hours for each row and column.
- Switch to another week and verify that the behavior is consistent.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
