### PR TITLE
Feat: display loading spinner until data is loaded

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -176,7 +176,7 @@ export const Report = () => {
       } else if (!didCancel) {
         await getAllEntries(issues);
         setFilteredRecents(issues);
-        }
+      }
       toggleLoadingPage(false);
     };
     getRowData();

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -61,7 +61,7 @@ export const Report = () => {
   );
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
   const [showHidden, setShowHidden] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const context = React.useContext(AuthContext);
   const urlparams = useParams();
 
@@ -141,9 +141,13 @@ export const Report = () => {
 
   // If recentIssues has changed, do this...
   React.useEffect(() => {
+    if (recentIssues.length === 0) {
+      return;
+    }
     let didCancel = false;
 
     const getRowData = async () => {
+      toggleLoadingPage(true);
       const priorityIssues: IssueActivityPair[] = await getApiEndpoint(
         "/api/priority_entries",
         context
@@ -164,15 +168,16 @@ export const Report = () => {
         if (!didCancel) {
           const favorites = priorityIssues.filter((issue) => !issue.is_hidden);
           const hidden = priorityIssues.filter((issue) => issue.is_hidden);
-          getAllEntries([...favorites, ...hidden, ...nonPrioIssues]);
+          await getAllEntries([...favorites, ...hidden, ...nonPrioIssues]);
           setFilteredRecents(nonPrioIssues);
           setFavorites(favorites);
           setHidden(hidden);
         }
       } else if (!didCancel) {
-        getAllEntries(issues);
+        await getAllEntries(issues);
         setFilteredRecents(issues);
-      }
+        }
+      toggleLoadingPage(false);
     };
     getRowData();
     return () => {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes https://github.com/NBISweden/urdr/issues/906 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
- Used the already existing `isLoading` state to trigger the loading spinner when the data is still fetched. 
- Added a check in the `getRowData`-function so that it wouldn't be called twice, first when `recentIssues` is empty and then again when `recentIssues` is populated. 
- Added `await` in front of `getAllEntries` to ensure that the function completes its asynchronous operations before proceeding.

## Testing
1. Check out this branch and get both urdr and redmine up an running. Urdr-repo: https://github.com/NBISweden/urdr  Redmine-repo:https://github.com/NBISweden/ops-redmine
2. Log in if needed
3. Refresh the page and watch the spinner appear and then disappear when the data is loaded.
4. Go to a new week and see the spinner appear and disappear when the data is loaded. 

## Comments
I do think this should work, however, I'm a little uncertain what happens if the `recentIssues` are `0` due to that the user does not have any added recent issues. Would you be able to help me test this @andkaha ? (If you know how of course!) 

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
