### PR TITLE
Optimize fetching of time entries

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -108,18 +108,16 @@ export const Report = () => {
   };
 
   // Retrieve time entries for given rows
-  const getAllEntries = async (rows: IssueActivityPair[]) => {
+  const getAllEntries = async () => {
     let allEntries = [];
-    for await (let row of rows) {
-      const entries = await getTimeEntries(
-        row,
-        currentWeekArray[0],
-        currentWeekArray[4],
-        context,
-        "me"
-      );
-      allEntries.push(...entries);
-    }
+    const entries = await getTimeEntries(
+      undefined,
+      currentWeekArray[0],
+      currentWeekArray[4],
+      context,
+      "me"
+    );
+    allEntries.push(...entries);
     setTimeEntries(allEntries);
   };
 
@@ -156,6 +154,7 @@ export const Report = () => {
         context
       );
       const issues = [...recentIssues];
+      await getAllEntries();
       if (!!priorityIssues) {
         let nonPrioIssues: IssueActivityPair[] = [];
         issues.forEach((issue) => {
@@ -171,13 +170,11 @@ export const Report = () => {
         if (!didCancel) {
           const favorites = priorityIssues.filter((issue) => !issue.is_hidden);
           const hidden = priorityIssues.filter((issue) => issue.is_hidden);
-          await getAllEntries([...favorites, ...hidden, ...nonPrioIssues]);
           setFilteredRecents(nonPrioIssues);
           setFavorites(favorites);
           setHidden(hidden);
         }
       } else if (!didCancel) {
-        await getAllEntries(issues);
         setFilteredRecents(issues);
       }
       toggleLoadingPage(false);
@@ -420,7 +417,7 @@ export const Report = () => {
         unsavedEntries.push(entry);
       }
     }
-    await getAllEntries([...favorites, ...hidden, ...filteredRecents]);
+    await getAllEntries();
     setNewTimeEntries(unsavedEntries);
     toggleLoadingPage(false);
     if (unsavedEntries.length === 0) {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -108,23 +108,11 @@ export const Report = () => {
     setIsLoading(state);
   };
 
-  // Retrieve time entries for given rows
-  const getAllEntries = async () => {
-    let allEntries = [];
-    const entries = await getTimeEntries(
-      undefined,
-      currentWeekArray[0],
-      currentWeekArray[4],
-      context,
-      "me"
-    );
-    allEntries.push(...entries);
-    setTimeEntries(allEntries);
-
-    if (allEntries.length > 0) {
+  React.useEffect(() => {
+    if (timeEntries.length > 0) {
       setShowTotalHours(true);
     }
-  };
+  }, [timeEntries]);
 
   // If weekTravelDay changes, do this...
   React.useEffect(() => {
@@ -159,7 +147,14 @@ export const Report = () => {
         context
       );
       const issues = [...recentIssues];
-      await getAllEntries();
+      const entries = await getTimeEntries(
+        undefined,
+        currentWeekArray[0],
+        currentWeekArray[4],
+        context,
+        "me"
+      );
+      setTimeEntries(entries);
       if (!!priorityIssues) {
         let nonPrioIssues: IssueActivityPair[] = [];
         issues.forEach((issue) => {
@@ -422,7 +417,14 @@ export const Report = () => {
         unsavedEntries.push(entry);
       }
     }
-    await getAllEntries();
+    const entries = await getTimeEntries(
+      undefined,
+      currentWeekArray[0],
+      currentWeekArray[4],
+      context,
+      "me"
+    );
+    setTimeEntries(entries);
     setNewTimeEntries(unsavedEntries);
     toggleLoadingPage(false);
     if (unsavedEntries.length === 0) {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1036 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement
 
## List of changes made
<!-- Specify what changes have been made and why -->
- time entries for one week are now fetched in one call to the Redmine API instead of row by row

## Testing
<!-- Please delete options that are not relevant -->
On the develop branch: 
- open your local urdr in the browser
- switch between weeks and look at the network tab in the dev tools: you will see one API call per row. In my setup, each one took between 100 and 200ms.

On this PR's git branch:
- do the same as above: you will see only one API call for the time entries of the current week. In my setup it took between 200 and 400ms --> much less than the sum of all displayed rows.

## Further comments
<!-- Specify questions or related information -->
The page load is still somewhat slow due to a slow fetch of `priority_entries`. That fetch is not connected to Redmine but to our own API and database and should be optimized there. There is a [follow-up issue](https://github.com/NBISweden/urdr/issues/1058) for this.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
