### PR TITLE
use getISOWeekYear to determine current year

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { Help } from "./pages/Help";
 import { AbsencePlanner } from "./pages/AbsencePlanner";
 import { AuthProvider } from "./components/AuthProvider";
 import { ProtectedRoute } from "./components/ProtectedRoute";
-import { getISOWeek } from "date-fns";
+import { getISOWeek, getISOWeekYear } from "date-fns";
 import { ConfirmDialogProvider } from "./components/ConfirmDialogProvider";
 import { EditPeriodDialogProvider } from "./components/EditPeriodDialogProvider";
 
@@ -16,7 +16,7 @@ import { EditPeriodDialogProvider } from "./components/EditPeriodDialogProvider"
 // If none of these apply, redirect to /report/year/week using
 // current year and week and replace the history element.
 export const App = () => {
-  const currentYear: number = new Date().getFullYear();
+  const currentYear: number = getISOWeekYear(new Date());
   const currentWeek: number = getISOWeek(new Date());
 
   return (


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1031

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- use `getISOWeekYear` instead of `getFullYear` to avoid mismatch between week and year during the last or first week of a year. 
- Read more about the function in the  [date library's documentation](https://date-fns.org/v4.1.0/docs/getISOWeekYear)

## Testing
<!-- Please delete options that are not relevant -->
I really don't know how to test this because it only happens on certain dates. 
I suppose you could fiddle with your computer's date settings but I didn't do that. So I actually didn't test this and trust the date library's documentation. At least it doesn't break functionality during the rest of the year, as far as I can see.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
