### PR TITLE
feat: grouping dependabot PRs automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      frontend-dependencies:
+      frontend-npm:
         patterns:
           - "*"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      backend-dependencies:
+      backend-gomod:
         patterns:
           - "*"
       

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,52 @@ updates:
     directory: "backend/"
     schedule:
       interval: "monthly"
+    groups:
+      backend-dependencies:
+        patterns:
+          - "*"
       
   - package-ecosystem: "npm"
     directory: "frontend/"
     schedule:
       interval: "monthly"
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "frontend/"
     schedule:
       interval: "monthly"
+    groups:
+      frontend-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "backend/"
     schedule:
       interval: "monthly"
+    groups:
+      backend-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "production/"
     schedule:
       interval: "monthly"
+    groups:
+      production-docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "node/"
     schedule:
       interval: "monthly"
+    groups:
+      node-docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

According to a team discussion to merge dependabot PR:s into a larger branch there is a new functionality in dependabot where you can automatically group dependabot PR:s. 

[Github documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups) about dependabot
Check [this article](https://slar.se/dependabots-dependency-grouping.html) which I followed to make the suggested changes

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## List of changes made
Under each package ecosystem I added the groups attribute, a name and a wildcard pattern. The name will be used in the PR and the pattern takes everything under the specific folder

## Testing
I don't know how to test this in advance than see what the next dependabot will do

## Further comments
This is experimental so let me know your thoughts

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
