### PR TITLE
fix: Apply the development changes to the production webpack config

### DIFF
--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -2,6 +2,9 @@ const path = require('path')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
+const gitBranch = process.env.GIT_BRANCH
+const gitHash = process.env.GIT_HASH
+
 module.exports = {
   mode: 'production',
   entry: {
@@ -70,7 +73,9 @@ module.exports = {
       'process.env.PUBLIC_API_URL': JSON.stringify(process.env.PUBLIC_API_URL),
       'process.env.PUBLIC_REDMINE_URL': JSON.stringify(
         process.env.PUBLIC_REDMINE_URL
-      )
+      ),
+    'process.env.GIT_BRANCH': JSON.stringify(gitBranch),
+    'process.env.GIT_HASH': JSON.stringify(gitHash)
     }),
     new HtmlWebpackPlugin({
       filename: 'index.html',

--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -74,8 +74,8 @@ module.exports = {
       'process.env.PUBLIC_REDMINE_URL': JSON.stringify(
         process.env.PUBLIC_REDMINE_URL
       ),
-    'process.env.GIT_BRANCH': JSON.stringify(gitBranch),
-    'process.env.GIT_HASH': JSON.stringify(gitHash)
+      'process.env.GIT_BRANCH': JSON.stringify(gitBranch),
+      'process.env.GIT_HASH': JSON.stringify(gitHash)
     }),
     new HtmlWebpackPlugin({
       filename: 'index.html',


### PR DESCRIPTION
Hotfix: Apply the development changes to the production webpack config. Causes JS errors relating to `process` otherwise.

Once this is merged, I'll make a new release.
 
## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made

The `webpack.config.prod.js` lacked the setting of the `gitHash` and `gitBranch` variables from the environment.

## Testing
<!-- Please delete options that are not relevant -->

Testing:

```
$ git pull
$ git checkout release/20250319
$ git pull
$ cd production
$ cat undr.env    # to see that it exists and that it looks valid
$ docker compose build
$ docker up
```

Check browser.



## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
