### PR TITLE
fix: show sums when editing new week

### DIFF
--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -124,10 +124,12 @@ export const Report = () => {
   };
 
   React.useEffect(() => {
-    if (timeEntries.length > 0) {
+    if (timeEntries.length > 0 || newTimeEntries.length > 0) {
       setShowTotalHours(true);
+    } else {
+      setShowTotalHours(false);
     }
-  }, [timeEntries]);
+  }, [timeEntries, newTimeEntries]);
 
   // If weekTravelDay changes, do this...
   React.useEffect(() => {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1084.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- The total hours are now displayed when time entries are being added to a new, unsaved week

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
![image](https://github.com/user-attachments/assets/3e5bde2e-05e9-4019-b4ba-6d45e399ac3c)

## Testing
<!-- Please delete options that are not relevant -->
- Add time to a new, unsaved week and verify that the total hours are shown before (and after...) saving.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
