### PR TITLE
fix: Don't build containers or bump version on "develop" branch

### DIFF
--- a/.github/workflows/create_packages.yml
+++ b/.github/workflows/create_packages.yml
@@ -5,7 +5,6 @@ name: Create packages
 "on":
   push:
     branches:
-      - develop
       - main
       - testing-github-actions
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1093 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made

The `create_packages.yml` GitHub workflow will no longer trigger for merges to the `develop` branch.

