### PR TITLE
fix: Collect all Docker dependency updates in the same "dependency group"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      frontend-docker:
+      all-docker:
         patterns:
           - "*"
 
@@ -32,7 +32,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      backend-docker:
+      all-docker:
         patterns:
           - "*"
 
@@ -41,7 +41,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      production-docker:
+      all-docker:
         patterns:
           - "*"
 
@@ -50,6 +50,6 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      node-docker:
+      all-docker:
         patterns:
           - "*"


### PR DESCRIPTION
This PR tweaks the dependabot grouping of Docker-related dependencies by adding them to the same "dependency group" regardless of which project directory the corresponding files are in.

This makes it easier to ensure that Docker dependencies are in sync across the project.