### PR TITLE
Show only full-time absence in the past

### DIFF
--- a/frontend/src/pages/AbsencePlanner.tsx
+++ b/frontend/src/pages/AbsencePlanner.tsx
@@ -284,7 +284,7 @@ export const AbsencePlanner = () => {
     for (const validIssueId of validIssueIds) {
       let currentInterval: AbsenceInterval | null = null;
       const filteredEntries = sortedEntries.filter(
-        (entry) => entry.issue.id === validIssueId
+        (entry) => entry.issue.id === validIssueId && entry.hours === 8
       );
       for (let i = 0; i < filteredEntries.length; i++) {
         const entry = filteredEntries[i];
@@ -298,7 +298,9 @@ export const AbsencePlanner = () => {
               currentInterval.endDate = currentDate;
               currentInterval.entryIds.push(entry.id);
             } else {
-              intervals.push(currentInterval);
+              currentInterval.endDate >= today
+                ? intervals.push(currentInterval)
+                : null;
               currentInterval = {
                 startDate: currentDate,
                 endDate: currentDate,
@@ -318,11 +320,14 @@ export const AbsencePlanner = () => {
           }
         }
       }
-      if (currentInterval && intervals.indexOf(currentInterval) === -1) {
+      if (
+        currentInterval &&
+        intervals.indexOf(currentInterval) === -1 &&
+        currentInterval.endDate >= today
+      ) {
         intervals.push(currentInterval);
       }
     }
-
     return intervals;
   }
 

--- a/frontend/src/pages/AbsencePlanner.tsx
+++ b/frontend/src/pages/AbsencePlanner.tsx
@@ -77,8 +77,10 @@ export const AbsencePlanner = () => {
   const selectDates: ({}) => any = useSelectDates();
 
   const today = startOfDay(new Date());
-  const absenceFrom: Date = new Date(new Date().setMonth(today.getMonth() - 1));
-  const absenceTo: Date = new Date(new Date().setMonth(today.getMonth() + 12));
+  const absenceFrom: Date = new Date(
+    new Date().setMonth(today.getMonth() - 24)
+  );
+  const absenceTo: Date = new Date(new Date().setMonth(today.getMonth() + 24));
 
   const toggleLoadingPage = (state: boolean) => {
     setIsLoading(state);


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes issue #1068 .

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
In the absence planner view
- only absence periods with 8 hours logged per day are shown 
- only absence periods that end today or later are shown

## Testing
<!-- Please delete options that are not relevant -->
- To make sure that you can see the changes of this PR you will need to log some absence periods, manually or using the absence planner tool:
1. a full-time absence starting and ending in the past
2. a full-time absence starting in the past and ending today
3. a full-time absence starting in the past and ending in the future
4. a full-time absence starting and ending in the future
5. a part-time absence starting and ending in the future

- look at the absence planner page. You should only see periods 2, 3 and 4.

## Further comments
<!-- Specify questions or related information -->
Apart from the above mentioned changes this PR also extends the period that is searched for absences to two years before and after today.
As the absence planner also is supposed to handle parental leave, the current period (1 month in the past and 12 months in the future) is too short for reality.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
