### PR TITLE
fix: fixing the groupSelect to take number as a parameter

### DIFF
--- a/frontend/src/components/VacationOverview/GroupSelect.tsx
+++ b/frontend/src/components/VacationOverview/GroupSelect.tsx
@@ -3,16 +3,16 @@ import React from "react";
 
 type Props = {
     groups: Group[];
-    selectedGroup: string | null;
-    onChange: (groupId: string) => void;
+    selectedGroup: number | null;
+    onChange: (groupId: number) => void;
 };
 
 export const GroupSelect: React.FC<Props> = ({ groups, selectedGroup, onChange }) => {
     return (
-        <select className="group-select" onChange={(e) => onChange(e.target.value)} value={selectedGroup ?? ''}>
+        <select className="group-select" onChange={(e) => onChange(Number(e.target.value))} value={selectedGroup ?? ''}>
             {groups &&
                 groups.map((group) => (
-                    <option key={group.id}  value={group.name}>
+                    <option key={group.id}  value={group.id}>
                         {group.name}
                     </option>
                 ))}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR relates to #1094 . 

A change from group. name to group.id caused the dropdown to stop working.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
- Changing the arguments from string -> number

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
