### PR TITLE
feat: save settings for vacation overview groups

### DIFF
--- a/frontend/src/components/VacationOverview/VacationOverview.tsx
+++ b/frontend/src/components/VacationOverview/VacationOverview.tsx
@@ -2,161 +2,99 @@ import "../../index.css";
 import React, { useState, useMemo, useContext, useEffect } from "react";
 import { VacationTable } from "./VacationTable";
 import { AuthContext } from "../AuthProvider";
-import { Group, UserSetting } from "../../model";
-import { getApiEndpoint, PUBLIC_API_URL } from "../../utils";
-import { fetchVacationData, generateWeeks, groupWeeksByMonth} from './utils';
+import { Group } from "../../model";
+import {
+  getGroups,
+  getSavedGroup,
+  selectGroup,
+  saveSettings,
+  fetchVacationData,
+  generateWeeks,
+  groupWeeksByMonth,
+} from "./utils";
 import { GroupSelect } from "./GroupSelect";
 
 export const VacationOverview = () => {
-    const [groups, setGroups] = useState<Group[]>([]);
-    const [vacationData, setVacationData] = useState<{ [userId: string]: number[] }>({});
-    const [selectedGroup, setSelectedGroup]= useState<number | null>(null);
-    const [savedGroup, setSavedGroup] = useState<number | null>(null);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [vacationData, setVacationData] = useState<{
+    [userId: string]: number[];
+  }>({});
+  const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
+  const [savedGroup, setSavedGroup] = useState<number | null>(null);
 
-    const context = useContext(AuthContext);
+  const context = useContext(AuthContext);
 
-    const getGroups = async () => {
-        const groups: Group[] = await getApiEndpoint("/api/groups", context);
-        if (!groups) {
-            return [];
-        }
-        return groups;  
+  useEffect(() => {
+    const fetchGroupData = async () => {
+      const groups = await getGroups(context);
+      setGroups(groups);
+
+      const groupId = await getSavedGroup(context);
+      setSavedGroup(groupId);
+
+      const selectedGroup = selectGroup(groups, groupId);
+      setSelectedGroup(selectedGroup);
+    };
+    fetchGroupData();
+  }, []);
+
+  const selectedGroupData = groups.find((group) => group.id === selectedGroup);
+  const weeks = useMemo(() => generateWeeks(), []);
+  const monthGroups = useMemo(() => groupWeeksByMonth(weeks), [weeks]);
+
+  useEffect(() => {
+    if (!selectedGroupData) return;
+
+    const loadVacationData = async () => {
+      const userIds = selectedGroupData.users.map((user) => ({ id: user.id }));
+      const data = await fetchVacationData(userIds, weeks, context);
+      setVacationData(data);
     };
 
-    const getSavedGroup = async () => {
-        const groupSettingArray: UserSetting[] = await getApiEndpoint("/api/setting?name=group", context);
-        const groupSettingObject = groupSettingArray.find((setting) => setting.name === "group");
-        const { value } = groupSettingObject || {};
-        const groupId = Number(value);
-        if (isNaN(groupId)) {
-            return;
-        }
-        return groupId;
-    };
+    loadVacationData();
+  }, [selectedGroupData, context]);
 
-    const selectGroup = (groups: Group[], savedGroupId: number | null) => {
-        let selectedGroup = null;
+  useEffect(() => {
+    if (savedGroup === selectedGroup) return;
 
-        if (groups.length > 0) {
-            const savedGroup = groups.find((group) => group.id === savedGroupId);
-            const nbisgroup = groups.find((group) => group.name === "NBIS staff");
-            if (savedGroup) {
-                selectedGroup = savedGroup.id;
-            } else if (nbisgroup) {
-                selectedGroup = nbisgroup.id;
-            } else {
-                selectedGroup = groups[0].id;
-            }
-        }
-        return selectedGroup;
-    };
-
-    const saveSettings = async (
-      settings: { name: string; value: string }[],
-      context: any
-    ) => {
-      const url = new URL(`${PUBLIC_API_URL}/api/setting`);
-      url.search = new URLSearchParams({
-        name: settings[0].name,
-        value: settings[0].value,
-      }).toString();
-      const headers = new Headers({
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-      });
-
-      try {
-        const res = await fetch(url, {
-          method: "POST",
-          headers: headers,
-        });
-
-        if (res.ok) {
-          return true;
-        } else if (res.status === 401) {
-          context.setUser(null);
+    const settings = [
+      {
+        name: "group",
+        value: selectedGroup ? selectedGroup.toString() : "",
+      },
+    ];
+    saveSettings(settings, context)
+      .then((result) => {
+        if (result) {
+          setSavedGroup(selectedGroup);
         } else {
-          throw new Error("There was an error accessing the settings endpoint");
+          console.log("Failed to save group");
         }
-      } catch (error) {
-        console.error(error);
-        return false;
-      }
-    }
+      })
+      .catch((error) => {
+        console.error("Error saving group:", error);
+      });
+  }, [savedGroup, selectedGroup]);
 
-    useEffect(() => {
-        const fetchGroupData = async () => {
-            const groups = await getGroups();
-            setGroups(groups);
-
-            const groupId = await getSavedGroup();
-            setSavedGroup(groupId);
-
-            const selectedGroup = selectGroup(groups, groupId);
-            setSelectedGroup(selectedGroup);
-        };
-        fetchGroupData();
-    }, []);
-
-    const selectedGroupData = groups.find((group) => group.id === selectedGroup)
-    const weeks = useMemo(() => generateWeeks(), []);
-    const monthGroups = useMemo(() => groupWeeksByMonth(weeks), [weeks]);
-
-    useEffect(() => {
-        if (!selectedGroupData) return;
-
-        const loadVacationData = async () => {
-            const userIds =  selectedGroupData.users.map(user => ({ id: user.id }));
-            const data = await fetchVacationData(userIds, weeks, context);
-            setVacationData(data);
-        };
-
-        loadVacationData();
-    }, [selectedGroupData, context]);
-
-    useEffect(() => {
-        if (savedGroup === selectedGroup) return;
-
-        const settings = [
-            {
-                name: "group",
-                value: selectedGroup ? selectedGroup.toString() : "",
-            },
-        ];
-        saveSettings(settings, context)
-            .then((result) => {
-                if (result) {
-                    setSavedGroup(selectedGroup);
-                } else {
-                    console.log("Failed to save group");
-                }
-            }
-            )
-            .catch((error) => {
-                console.error("Error saving group:", error);
-            }
-        );
-    }, [savedGroup, selectedGroup]);
-
-    return (
-        <div className="vacation-overview">
-            {groups.length === 0 ? (
-                <p>Du tillhör inga grupper ännu.</p>
-            ) : (
-                <>
-                    <GroupSelect
-                        groups={groups}
-                        selectedGroup={selectedGroup}
-                        onChange={setSelectedGroup}
-                    />
-                    <VacationTable
-                        group={selectedGroupData}
-                        weeks={weeks}
-                        monthGroups={monthGroups}
-                        vacationData={vacationData}
-                    />
-                </>
-            )}
-        </div>
-    );
-}
+  return (
+    <div className="vacation-overview">
+      {groups.length === 0 ? (
+        <p>Du tillhör inga grupper ännu.</p>
+      ) : (
+        <>
+          <GroupSelect
+            groups={groups}
+            selectedGroup={selectedGroup}
+            onChange={setSelectedGroup}
+          />
+          <VacationTable
+            group={selectedGroupData}
+            weeks={weeks}
+            monthGroups={monthGroups}
+            vacationData={vacationData}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/VacationOverview/VacationOverview.tsx
+++ b/frontend/src/components/VacationOverview/VacationOverview.tsx
@@ -1,35 +1,36 @@
 import "../../index.css";
-import React, { useState, useMemo } from "react";
-import {VacationTable} from "./VacationTable";
-import {AuthContext} from "../AuthProvider";
-import {Group} from "../../model";
-import {getApiEndpoint} from "../../utils";
-import {fetchVacationData, generateWeeks, groupWeeksByMonth} from './utils';
-import {GroupSelect} from "./GroupSelect";
-
+import React, { useState, useMemo, useContext, useEffect } from "react";
+import { VacationTable } from "./VacationTable";
+import { AuthContext } from "../AuthProvider";
+import { Group } from "../../model";
+import { getApiEndpoint } from "../../utils";
+import { fetchVacationData, generateWeeks, groupWeeksByMonth} from './utils';
+import { GroupSelect } from "./GroupSelect";
 
 export const VacationOverview = () => {
-    const context = React.useContext(AuthContext);
+    const [groups, setGroups] = useState<Group[]>([]);
+    const [vacationData, setVacationData] = useState<{ [userId: string]: number[] }>({});
+    const [selectedGroup, setSelectedGroup]= useState<number | null>(null);
+
+    const context = useContext(AuthContext);
+
     const getGroups = async () => {
         const groups: Group[] = await getApiEndpoint("/api/groups", context);
         setGroups(groups);
 
         const nbisGroup = groups.find((group) => group.name === "NBIS staff");
-
         if (nbisGroup) {
             setSelectedGroup(nbisGroup.id);
         } else if (groups.length > 0) {
             setSelectedGroup(groups[0].id);
         }
     };
-    const [groups, setGroups] = useState<Group[]>([]);
-    const [vacationData, setVacationData] = useState<{ [userId: string]: number[] }>({});
-    let [selectedGroup, setSelectedGroup]= useState<number | null>(null);
+
     const selectedGroupData = groups.find((group) => group.id === selectedGroup)
     const weeks = useMemo(() => generateWeeks(), []);
     const monthGroups = useMemo(() => groupWeeksByMonth(weeks), [weeks]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!selectedGroupData) return;
 
         const loadVacationData = async () => {
@@ -41,10 +42,9 @@ export const VacationOverview = () => {
         loadVacationData();
     }, [selectedGroupData, context]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         getGroups();
     }, []);
-
 
     return (
         <div className="vacation-overview">

--- a/frontend/src/components/VacationOverview/utils.ts
+++ b/frontend/src/components/VacationOverview/utils.ts
@@ -1,111 +1,185 @@
-import {addDays, addWeeks, format, getISOWeek, startOfWeek} from "date-fns";
-import {sv} from "date-fns/locale";
-import {WeekInfo, MonthGroup} from "./types";
-import {IdName, IssueActivityPair} from "../../model";
-import {getTimeEntries} from "../../utils";
+import { addDays, addWeeks, format, getISOWeek, startOfWeek } from "date-fns";
+import { sv } from "date-fns/locale";
+import { WeekInfo, MonthGroup } from "./types";
+import { IdName, IssueActivityPair, Group, UserSetting } from "../../model";
+import { getTimeEntries, getApiEndpoint, PUBLIC_API_URL } from "../../utils";
+
+export const getGroups = async (context: any) => {
+  const groups: Group[] = await getApiEndpoint("/api/groups", context);
+  if (!groups) {
+    return [];
+  }
+  return groups;
+};
+
+export const getSavedGroup = async (context: any) => {
+  const groupSettingArray: UserSetting[] = await getApiEndpoint(
+    "/api/setting?name=group",
+    context
+  );
+  const groupSettingObject = groupSettingArray.find(
+    (setting) => setting.name === "group"
+  );
+  const { value } = groupSettingObject || {};
+  const groupId = Number(value);
+  if (isNaN(groupId)) {
+    return;
+  }
+  return groupId;
+};
+
+export const selectGroup = (groups: Group[], savedGroupId: number | null) => {
+  let selectedGroup = null;
+
+  if (groups.length > 0) {
+    const savedGroup = groups.find((group) => group.id === savedGroupId);
+    const nbisgroup = groups.find((group) => group.name === "NBIS staff");
+    if (savedGroup) {
+      selectedGroup = savedGroup.id;
+    } else if (nbisgroup) {
+      selectedGroup = nbisgroup.id;
+    } else {
+      selectedGroup = groups[0].id;
+    }
+  }
+  return selectedGroup;
+};
+
+export const saveSettings = async (
+  settings: { name: string; value: string }[],
+  context: any
+) => {
+  const url = new URL(`${PUBLIC_API_URL}/api/setting`);
+  url.search = new URLSearchParams({
+    name: settings[0].name,
+    value: settings[0].value,
+  }).toString();
+  const headers = new Headers({
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  });
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: headers,
+    });
+
+    if (res.ok) {
+      return true;
+    } else if (res.status === 401) {
+      context.setUser(null);
+    } else {
+      throw new Error("There was an error accessing the settings endpoint");
+    }
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+};
 
 export const fetchVacationData = async (
-    users: { id: number }[],
-    weeks: { monday: Date }[],
-    context: any
+  users: { id: number }[],
+  weeks: { monday: Date }[],
+  context: any
 ): Promise<{ [userId: string]: number[] }> => {
-    const allUserVacation: { [userId: string]: number[] } = {};
+  const allUserVacation: { [userId: string]: number[] } = {};
 
-    const promises = users.map(async (user) => {
-        const timeEntries = await getVacationTimeEntries(
-            weeks[0].monday,
-            addDays(weeks[weeks.length - 1].monday, 4),
-            user.id.toString(),
-            context,
-        );
+  const promises = users.map(async (user) => {
+    const timeEntries = await getVacationTimeEntries(
+      weeks[0].monday,
+      addDays(weeks[weeks.length - 1].monday, 4),
+      user.id.toString(),
+      context
+    );
 
-        if (timeEntries) {
-            const userWeeks = new Set<number>();
+    if (timeEntries) {
+      const userWeeks = new Set<number>();
 
-            for (const entry of timeEntries) {
-                    const entryDate = new Date(entry.spent_on);
-                    const entryWeek = getISOWeek(entryDate);
-                    userWeeks.add(entryWeek);
-            }
+      for (const entry of timeEntries) {
+        const entryDate = new Date(entry.spent_on);
+        const entryWeek = getISOWeek(entryDate);
+        userWeeks.add(entryWeek);
+      }
 
-            return { userId: user.id, weeks: Array.from(userWeeks) };
-        }
+      return { userId: user.id, weeks: Array.from(userWeeks) };
+    }
 
-        return { userId: user.id, weeks: [] };
-    });
+    return { userId: user.id, weeks: [] };
+  });
 
-    const results = await Promise.all(promises);
+  const results = await Promise.all(promises);
 
-    results.forEach((result) => {
-        allUserVacation[result.userId] = result.weeks;
-    });
+  results.forEach((result) => {
+    allUserVacation[result.userId] = result.weeks;
+  });
 
-    return allUserVacation;
+  return allUserVacation;
 };
 
 const getVacationTimeEntries = async (
-    fromDate: Date,
-    toDate: Date,
-    user_id: string,
-    context: any
+  fromDate: Date,
+  toDate: Date,
+  user_id: string,
+  context: any
 ) => {
-    const vacationIssue: IdName = { id: 6995, name: "Vacation" };
-    const activity: IdName = { id: 19, name: "Absence (Vacation/VAB/Other)" };
+  const vacationIssue: IdName = { id: 6995, name: "Vacation" };
+  const activity: IdName = { id: 19, name: "Absence (Vacation/VAB/Other)" };
 
-    const absence_pair: IssueActivityPair = {
-        issue: vacationIssue,
-        activity,
-        custom_name: "",
-        is_hidden: false
-    };
+  const absence_pair: IssueActivityPair = {
+    issue: vacationIssue,
+    activity,
+    custom_name: "",
+    is_hidden: false,
+  };
 
-    const entries = await getTimeEntries(
-        absence_pair,
-        fromDate,
-        toDate,
-        context,
-        user_id
-    );
+  const entries = await getTimeEntries(
+    absence_pair,
+    fromDate,
+    toDate,
+    context,
+    user_id
+  );
 
-    return entries || [];
+  return entries || [];
 };
 
 export const generateWeeks = (numWeeks: number = 13): WeekInfo[] => {
-    const today = new Date();
-    const currentMonday = startOfWeek(addWeeks(today, 1), { weekStartsOn: 1 });
+  const today = new Date();
+  const currentMonday = startOfWeek(addWeeks(today, 1), { weekStartsOn: 1 });
 
-    const weeks: WeekInfo[] = [];
+  const weeks: WeekInfo[] = [];
 
-    for (let i = 0; i < numWeeks; i++) {
-        const weekStart = addWeeks(currentMonday, i);
-        const weekEnd = addDays(weekStart, 4); // Friday
+  for (let i = 0; i < numWeeks; i++) {
+    const weekStart = addWeeks(currentMonday, i);
+    const weekEnd = addDays(weekStart, 4); // Friday
 
-        const startDay = format(weekStart, 'd', { locale: sv });
-        const endDay = format(weekEnd, 'd', { locale: sv });
+    const startDay = format(weekStart, "d", { locale: sv });
+    const endDay = format(weekEnd, "d", { locale: sv });
 
-        const range = `${startDay}–${endDay}`; // Alltid dagnummer till dagnummer
+    const range = `${startDay}–${endDay}`; // Alltid dagnummer till dagnummer
 
-        weeks.push({
-            week: getISOWeek(weekStart),
-            dateRange: range,
-            monday: weekStart,
-        });
-    }
+    weeks.push({
+      week: getISOWeek(weekStart),
+      dateRange: range,
+      monday: weekStart,
+    });
+  }
 
-    return weeks;
+  return weeks;
 };
 export const groupWeeksByMonth = (weeks: WeekInfo[]): MonthGroup[] => {
-    const monthMap: { [month: string]: MonthGroup } = {};
+  const monthMap: { [month: string]: MonthGroup } = {};
 
-    weeks.forEach((week) => {
-        const month = format(week.monday, 'MMMM');
+  weeks.forEach((week) => {
+    const month = format(week.monday, "MMMM");
 
-        if (monthMap[month]) {
-            monthMap[month].colSpan += 1;
-        } else {
-            monthMap[month] = { name: month, colSpan: 1 };
-        }
-    });
+    if (monthMap[month]) {
+      monthMap[month].colSpan += 1;
+    } else {
+      monthMap[month] = { name: month, colSpan: 1 };
+    }
+  });
 
-    return Object.values(monthMap);
+  return Object.values(monthMap);
 };

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -71,3 +71,9 @@ export interface Group {
   name: string;
   users: IdName[];
 }
+
+export interface UserSetting {
+  id: number;
+  name: string;
+  value: string;
+}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1095.

<!-- Include below a description of the changes proposed in the pull request -->
This PR adds the functionality to save the selected group in the group selector so that the user does not have to select the group every time he/she navigates to the Absence page.

More details about the endpoint `api/setting` can be found in [this PR](https://github.com/NBISweden/urdr/pull/1104).

## Type of change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Added a new function, `getGroupSetting`, which, given that the user has a saved group, will return the group id. If `getGroupSetting` returns a group id, that group will be used as the default group in the group selector. If not, the default group will be NBIS staff.
- Added a new function, `saveSettings`. This function is called when the user selects another group (than the one currently saved) in the group selector.
- Refactored the `VacationOverview` component and moved `getGroups` and a new `selectGroup` function to the utils file.

## Testing
<!-- Please delete options that are not relevant -->
- Go to the Absence page. If you have a saved group, it will be selected by default in the group selector. If you do not have a saved group, NBIS staff will be selected by default.
- Select another group in the group selector. The selected group will be saved and used as the default group when you navigate to the Absence page again.
- Verify that the group selector works as expected and that the selected group is displayed correctly in the vacation overview.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
