### PR TITLE
feat: add loading spinner to vacation overview page

### DIFF
--- a/frontend/src/components/VacationOverview/GroupSelect.tsx
+++ b/frontend/src/components/VacationOverview/GroupSelect.tsx
@@ -9,13 +9,18 @@ type Props = {
 
 export const GroupSelect: React.FC<Props> = ({ groups, selectedGroup, onChange }) => {
     return (
-        <select className="group-select" onChange={(e) => onChange(Number(e.target.value))} value={selectedGroup ?? ''}>
-            {groups &&
-                groups.map((group) => (
-                    <option key={group.id}  value={group.id}>
-                        {group.name}
-                    </option>
-                ))}
-        </select>
-    )
-}
+        <div className="group-select-wrapper">
+            <label htmlFor="group-select">
+                Select group:
+            </label>
+            <select id="group-select" onChange={(e) => onChange(Number(e.target.value))} value={selectedGroup ?? ''}>
+                {groups &&
+                    groups.map((group) => (
+                        <option key={group.id}  value={group.id}>
+                            {group.name}
+                        </option>
+                    ))}
+            </select>
+        </div>
+    );
+};

--- a/frontend/src/components/VacationOverview/GroupSelect.tsx
+++ b/frontend/src/components/VacationOverview/GroupSelect.tsx
@@ -1,26 +1,32 @@
-import {Group} from "../../model";
 import React from "react";
+import { Group } from "../../model";
 
 type Props = {
-    groups: Group[];
-    selectedGroup: number | null;
-    onChange: (groupId: number) => void;
+  groups: Group[];
+  selectedGroup: number | null;
+  onChange: (groupId: number) => void;
 };
 
-export const GroupSelect: React.FC<Props> = ({ groups, selectedGroup, onChange }) => {
-    return (
-        <div className="group-select-wrapper">
-            <label htmlFor="group-select">
-                Select group:
-            </label>
-            <select id="group-select" onChange={(e) => onChange(Number(e.target.value))} value={selectedGroup ?? ''}>
-                {groups &&
-                    groups.map((group) => (
-                        <option key={group.id}  value={group.id}>
-                            {group.name}
-                        </option>
-                    ))}
-            </select>
-        </div>
-    );
+export const GroupSelect: React.FC<Props> = ({
+  groups,
+  selectedGroup,
+  onChange,
+}) => {
+  return (
+    <div className="group-select-wrapper">
+      <label htmlFor="group-select">Select group:</label>
+      <select
+        id="group-select"
+        onChange={(e) => onChange(Number(e.target.value))}
+        value={selectedGroup ?? ""}
+      >
+        {groups &&
+          groups.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+      </select>
+    </div>
+  );
 };

--- a/frontend/src/components/VacationOverview/VacationTable.tsx
+++ b/frontend/src/components/VacationOverview/VacationTable.tsx
@@ -1,59 +1,67 @@
-import React, {useState} from "react";
-import {Group} from "../../model";
-import {MonthGroup, WeekInfo} from "./types";
+import React from "react";
+import { Group } from "../../model";
+import { MonthGroup, WeekInfo } from "./types";
 
 type Props = {
-    group?: Group;
-    weeks: WeekInfo[];
-    monthGroups: MonthGroup[];
-    vacationData: { [userId: string]: number[] };
+  group?: Group;
+  weeks: WeekInfo[];
+  monthGroups: MonthGroup[];
+  vacationData: { [userId: string]: number[] };
 };
 
-export const VacationTable: React.FC<Props>  = ({group, weeks, monthGroups, vacationData}) => {
-    return (
-        <div className="table-wrapper">
-            <table className="vacation-table table-responsive" >
-                <thead>
-                {/* Months */}
-                <tr>
-                    <th></th>
-                    {monthGroups.map((month) => (
-                        <th key={month.name} colSpan={month.colSpan}>
-                            {month.name}
-                        </th>
-                    ))}
-                </tr>
+export const VacationTable: React.FC<Props> = ({
+  group,
+  weeks,
+  monthGroups,
+  vacationData,
+}) => {
+  return (
+    <div className="table-wrapper">
+      <table className="vacation-table table-responsive">
+        <thead>
+          {/* Months */}
+          <tr>
+            <th></th>
+            {monthGroups.map((month) => (
+              <th key={month.name} colSpan={month.colSpan}>
+                {month.name}
+              </th>
+            ))}
+          </tr>
 
-                {/* Weeks */}
-                <tr>
-                    <th></th>
-                    {weeks.map((week) => (
-                        <th key={week.week} className="week-header">
-                            <div> {week.week} </div>
-                            <div>{week.dateRange}</div>
-                        </th>
-                    ))}
+          {/* Weeks */}
+          <tr>
+            <th></th>
+            {weeks.map((week) => (
+              <th key={week.week} className="week-header">
+                <div> {week.week} </div>
+                <div>{week.dateRange}</div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {group &&
+            group.users
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((user) => (
+                <tr key={user.id}>
+                  <td className="user-name">{user.name}</td>
+                  {weeks.map((week) => {
+                    const hasVacation = vacationData[user.id]?.includes(
+                      week.week
+                    );
+                    return (
+                      <td
+                        key={week.week}
+                        className={hasVacation ? "vacation-cell" : ""}
+                      ></td>
+                    );
+                  })}
                 </tr>
-                </thead>
-                <tbody>
-                {group && group.users.sort((a, b) => a.name.localeCompare(b.name)).map((user) => (
-                    <tr key={user.id}>
-                        <td className="user-name">{user.name}</td>
-                        {weeks.map((week) => {
-                            const hasVacation = vacationData[user.id]?.includes(week.week);
-                            return (
-                                <td
-                                    key={week.week}
-                                    className={hasVacation ? "vacation-cell" : ""}
-                                >
-                                </td>
-                            );
-                        })}
-                    </tr>
-                ))}
-                </tbody>
-            </table>
-        </div>
-
-    )
-}
+              ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1013,9 +1013,17 @@ Other button classes are defined further down together with other classes for th
   margin: 0.75rem auto;
 }
 
-.group-select {
-  margin: 0.5rem auto;
-  padding: 0.25rem;
+.group-select-wrapper {
+  padding: 1rem 0;
+
+  label {
+    display: block;
+    margin-bottom: 0.25rem;
+  }
+
+  select {
+    padding: 0.25rem;
+  }
 }
 
 .calendar-table {
@@ -1079,11 +1087,6 @@ Other button classes are defined further down together with other classes for th
 .apply-dates-button {
   height: 3rem;
   width: 8rem;
-}
-
-.group-select-wrapper {
-  margin-top: 2rem;
-  margin-bottom: 3rem;
 }
 
 /* ModalDialog styles */

--- a/frontend/src/pages/VacationOverview.tsx
+++ b/frontend/src/pages/VacationOverview.tsx
@@ -52,10 +52,15 @@ export const VacationOverview = () => {
 
     const loadVacationData = async () => {
       setLoadingVacationData(true);
-      const userIds = selectedGroupData.users.map((user) => ({ id: user.id }));
-      const data = await fetchVacationData(userIds, weeks, context);
-      setVacationData(data);
-      setLoadingVacationData(false);
+      try {
+        const userIds = selectedGroupData.users.map((user) => ({ id: user.id }));
+        const data = await fetchVacationData(userIds, weeks, context);
+        setVacationData(data);
+      } catch (error) {
+        console.error("Error fetching vacation data:", error);
+      } finally {
+        setLoadingVacationData(false);
+      }
     };
 
     loadVacationData();

--- a/frontend/src/pages/VacationOverview.tsx
+++ b/frontend/src/pages/VacationOverview.tsx
@@ -10,10 +10,10 @@ import {
   groupWeeksByMonth,
 } from "../components/VacationOverview/utils";
 import { GroupSelect } from "../components/VacationOverview/GroupSelect";
-import {VacationTable} from "../components/VacationOverview/VacationTable";
-import {AuthContext} from "../components/AuthProvider";
-import {Group} from "../model";
-import {HeaderUser} from "../components/HeaderUser";
+import { VacationTable } from "../components/VacationOverview/VacationTable";
+import { AuthContext } from "../components/AuthProvider";
+import { Group } from "../model";
+import { HeaderUser } from "../components/HeaderUser";
 import { ClimbingBoxLoader } from "react-spinners";
 import { LoadingOverlay } from "../components/LoadingOverlay";
 
@@ -24,7 +24,8 @@ export const VacationOverview = () => {
   }>({});
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
   const [savedGroup, setSavedGroup] = useState<number | null>(null);
-  const [loadingVacationData, setLoadingVacationData] = useState<boolean>(false);
+  const [loadingVacationData, setLoadingVacationData] =
+    useState<boolean>(false);
 
   const context = useContext(AuthContext);
 
@@ -105,25 +106,24 @@ export const VacationOverview = () => {
         <HeaderUser username={context.user ? context.user.login : ""} />
       </header>
       <main className="page-wrapper">
-          {groups.length === 0 ? (
-              <p>Du tillhör inga grupper ännu.</p>
-          ) : (
-              <>
-                <GroupSelect
-                    groups={groups}
-                    selectedGroup={selectedGroup}
-                    onChange={setSelectedGroup}
-                />
-                <VacationTable
-                    group={selectedGroupData}
-                    weeks={weeks}
-                    monthGroups={monthGroups}
-                    vacationData={vacationData}
-                />
-              </>
-          )}
+        {groups.length === 0 ? (
+          <p>Du tillhör inga grupper ännu.</p>
+        ) : (
+          <>
+            <GroupSelect
+              groups={groups}
+              selectedGroup={selectedGroup}
+              onChange={setSelectedGroup}
+            />
+            <VacationTable
+              group={selectedGroupData}
+              weeks={weeks}
+              monthGroups={monthGroups}
+              vacationData={vacationData}
+            />
+          </>
+        )}
       </main>
     </>
-
   );
 };

--- a/frontend/src/pages/VacationOverview.tsx
+++ b/frontend/src/pages/VacationOverview.tsx
@@ -14,6 +14,8 @@ import {VacationTable} from "../components/VacationOverview/VacationTable";
 import {AuthContext} from "../components/AuthProvider";
 import {Group} from "../model";
 import {HeaderUser} from "../components/HeaderUser";
+import { ClimbingBoxLoader } from "react-spinners";
+import { LoadingOverlay } from "../components/LoadingOverlay";
 
 export const VacationOverview = () => {
   const [groups, setGroups] = useState<Group[]>([]);
@@ -22,6 +24,7 @@ export const VacationOverview = () => {
   }>({});
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
   const [savedGroup, setSavedGroup] = useState<number | null>(null);
+  const [loadingVacationData, setLoadingVacationData] = useState<boolean>(false);
 
   const context = useContext(AuthContext);
 
@@ -47,9 +50,11 @@ export const VacationOverview = () => {
     if (!selectedGroupData) return;
 
     const loadVacationData = async () => {
+      setLoadingVacationData(true);
       const userIds = selectedGroupData.users.map((user) => ({ id: user.id }));
       const data = await fetchVacationData(userIds, weeks, context);
       setVacationData(data);
+      setLoadingVacationData(false);
     };
 
     loadVacationData();
@@ -79,6 +84,19 @@ export const VacationOverview = () => {
 
   return (
     <>
+      {loadingVacationData && (
+        <LoadingOverlay>
+          <ClimbingBoxLoader
+            color="hsl(76deg 55% 53%)"
+            loading={loadingVacationData}
+            size={17}
+            width={4}
+            height={6}
+            radius={4}
+            margin={4}
+          />
+        </LoadingOverlay>
+      )}
       <header className="page-header">
         <h1 className="help-title">
           Vacation Overview


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1136.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- A loading spinner is shown while `vacationData` is being loaded.
- Added a label to the `GroupSelect` component.

## Testing
<!-- Please delete options that are not relevant -->
- Navigate to http://localhost:4567/vacation, select a group and view the spinner in action.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
