### PR TITLE
feat: show full-time parental leave in vacation overview

### DIFF
--- a/frontend/src/pages/VacationOverview.tsx
+++ b/frontend/src/pages/VacationOverview.tsx
@@ -5,8 +5,7 @@ import {
   getSavedGroup,
   selectGroup,
   saveSettings,
-  fetchVacationData,
-  fetchParentalLeaveData,
+  fetchAbsenceData,
   generateWeeks,
   groupWeeksByMonth,
 } from "../components/VacationOverview/utils";
@@ -54,15 +53,30 @@ export const VacationOverview = () => {
     const loadAbsenceData = async () => {
       setLoadingVacationData(true);
       try {
-        const userIds = selectedGroupData.users.map((user) => ({ id: user.id }));
-        const vacationData = await fetchVacationData(userIds, weeks, context);
-        const parentalLeaveData = await fetchParentalLeaveData(userIds, weeks, context);
+        const userIds = selectedGroupData.users.map((user) => ({
+          id: user.id,
+        }));
+        const vacationData = await fetchAbsenceData(
+          { id: 6995, name: "Vacation" },
+          userIds,
+          weeks,
+          context
+        );
+        const parentalLeaveData = await fetchAbsenceData(
+          { id: 6992, name: "Parental Leave" },
+          userIds,
+          weeks,
+          context
+        );
+
         // Merge parental data into vacation data under absenceData
         const absenceData = { ...vacationData };
 
         for (const userId in parentalLeaveData) {
           if (absenceData[userId]) {
-            absenceData[userId] = absenceData[userId].concat(parentalLeaveData[userId]);
+            absenceData[userId] = absenceData[userId].concat(
+              parentalLeaveData[userId]
+            );
           } else {
             absenceData[userId] = parentalLeaveData[userId];
           }


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1146.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Full-time Parental Leave Indication: If a user has reported full-time (8 hours) parental leave for at least one day in a week, that week will now be marked in the same way as vacation in the vacation overview table.
- Non-Full-Time Parental Leave: If a user has reported less than a full day (i.e., less than 8 hours) or more than a standard full day (i.e., more than 8 hours) of parental leave in a week, and there are no other vacation or full-time parental leave entries for that week, the week will not be marked in the vacation overview table.

## Testing
<!-- Please delete options that are not relevant -->
1. Navigate to `localhost:4567/report`.
2. Add 8 hours of parental leave on a day in a week with no other vacation or parental leave entries. Navigate to `localhost:4567/vacation` and verify that the week is marked in the table.
3. Add less than or more than 8 hours of parental leave on a day in a week with no other vacation or parental leave. Navigate to `localhost:4567/vacation` and verify that the week is _not_ marked in the table.
4. Ensure that weeks with vacation entries are still correctly marked in the table.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
