### PR TITLE
feat: extended search function to search for WABI ID as well

### DIFF
--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -32,6 +32,8 @@ export const QuickAdd = ({
   const isNumber = (s: string) => {
     return Number.isInteger(Number(s));
   };
+  const escapeUnderscore = (s: string) =>
+      s.replace(/(^|[^\\])_/g, '$1\\_');
 
   React.useEffect(() => {
     let endpoint = "/api/activities";
@@ -71,8 +73,9 @@ export const QuickAdd = ({
             const endpoint = `/api/issues?status_id=*&issue_id=${search.text}`;
             res = await getApiEndpoint(endpoint, context);
           } else {
-            res = await searchIssues(search.text);
-            byWabi = await searchIssuesByWabi(search.text)
+            const searchQuery = escapeUnderscore(search.text);
+            res = await searchIssues(searchQuery);
+            byWabi = await searchIssuesByWabi(searchQuery);
           }
 
           const map = new Map<number, Issue>();
@@ -120,8 +123,8 @@ export const QuickAdd = ({
 
   const WABI_CUSTOM_FIELD_ID = 30;
 
-  const searchIssuesByWabi = async (query: string) => {
-    const encoded = encodeURIComponent("~" + query);
+  const searchIssuesByWabi = async (searchQuery: string) => {
+    const encoded = encodeURIComponent("~" + searchQuery);
     const endpoint = `/api/issues?status_id=*&limit=5&cf_${WABI_CUSTOM_FIELD_ID}=${encoded}`;
     return await getApiEndpoint(endpoint, context) as { issues: Issue[] };
   };

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -25,7 +25,14 @@ export interface Issue {
   id: number;
   subject: string;
   project: IdName;
+  custom_fields?: CustomField[];
 }
+
+export type CustomField = {
+  id: number;
+  name: string;
+  value: string | null;
+};
 
 export interface TimeEntry {
   id?: number;


### PR DESCRIPTION
## Related issue
This PR closes #944.

The users want to search for the WABI id custom field as well to find the issue to report time.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
- In quick add component I extended the search to search for the WABI ID in the issues custom fields
- I extended the Issue model to contain a custom fields variable and created a CustomField model. 

## Screenshot of the fix
<img width="898" height="268" alt="image" src="https://github.com/user-attachments/assets/1c07460b-9b73-43e0-ab35-04dea5bb7b6c" />

## Testing
- As an administrator check the "use as filter" checkbox in the custom field for WABI ID, found if you go to administration > custom fields and then choose WABI ID custom field
- To find projects with WABI ID to test in the search, go to long term support projects in the local Redmine using the GUI:
<img width="546" height="806" alt="image" src="https://github.com/user-attachments/assets/b47e465a-ed09-466a-8c1d-28bd01eed181" />

- Choose one of the rounds and then look for issues that are in progress so that they have been assigned the WABI ID number.

## Further comments
- For this to work in production a Redmine admin has to check the "use as filter" checkbox in the custom field for WABI ID
- The rows in the time sheet are populated using the internal database in contrary to the search that goes directly to Redmine API not the Urdr database. Since the issue clearly states that the search function should include WABI the rows in the time sheet are left as is showing the issue number and subject as before. This could though be a separate issue, adding the custom fields to the database or fetching the WABI id

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
