### PR TITLE
Add a weekpicker for the starting week of the table

### DIFF
--- a/frontend/src/components/VacationOverview/VacationTable.tsx
+++ b/frontend/src/components/VacationOverview/VacationTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import { Group } from "../../model";
 import { format, addDays } from "date-fns";
 import { ArrowDirection, MonthGroup, WeekInfo } from "./types";
@@ -47,6 +47,8 @@ export const VacationTable: React.FC<Props> = ({
           <span className="legend-label">Parental Leave</span>
           <span className="legend-color parental"></span>
         </div>
+      </div>
+      <div>
       </div>
       <table className="vacation-table table-responsive">
         <thead>

--- a/frontend/src/components/WeekPicker.tsx
+++ b/frontend/src/components/WeekPicker.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import DatePicker from "react-datepicker";
+
+type Props = {
+    onWeekDateChange: (newDate: Date) => void;
+    startDate: Date;
+    labelText: string;
+}
+
+
+export const WeekPicker : React.FC<Props> = ({
+    startDate,
+    onWeekDateChange,
+    labelText
+}) => {
+    return (
+        <div className="week-picker-wrapper">
+            <label htmlFor="week-picker">{labelText}</label>
+            <DatePicker
+                id="week-picker"
+                selected={startDate}
+                onChange={(date: Date) => onWeekDateChange(date)}
+                dateFormat="I - R"
+                showWeekNumbers
+                showWeekPicker
+            />
+        </div>
+
+    )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1102,16 +1102,36 @@ Other button classes are defined further down together with other classes for th
 }
 
 .group-select-wrapper {
+  display: flex;
+  flex-direction: column;
   padding: 1rem 0;
+}
 
-  label {
-    display: block;
+.group-select-wrapper label {
     margin-bottom: 0.25rem;
   }
 
-  select {
+.group-select-wrapper select {
     padding: 0.25rem;
   }
+
+.top-overview-container {
+  display: flex;
+  gap: 0.65rem;
+}
+
+.week-picker-wrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+}
+
+.week-picker-wrapper label {
+  margin-bottom: 0.25rem;
+}
+
+.week-picker-wrapper select {
+  padding: 0.25rem;
 }
 
 .calendar-table {

--- a/frontend/src/pages/VacationOverview.tsx
+++ b/frontend/src/pages/VacationOverview.tsx
@@ -18,6 +18,7 @@ import { HeaderUser } from "../components/HeaderUser";
 import { ClimbingBoxLoader } from "react-spinners";
 import { LoadingOverlay } from "../components/LoadingOverlay";
 import { ArrowDirection, WeekInfo } from "../components/VacationOverview/types";
+import {WeekPicker} from "../components/WeekPicker";
 
 export const VacationOverview = () => {
   const [groups, setGroups] = useState<Group[]>([]);
@@ -153,6 +154,10 @@ export const VacationOverview = () => {
     return;
   };
 
+  const handleWeekChange =(newDate: Date) => {
+    setStartDate(newDate)
+  }
+
   const extendVacationData = async (monday: Date) => {
     if (fetchedWeeks.includes(getISOWeek(monday))) {
       return;
@@ -207,11 +212,19 @@ export const VacationOverview = () => {
           <p>Du tillhör inga grupper ännu.</p>
         ) : (
           <>
-            <GroupSelect
-              groups={groups}
-              selectedGroup={selectedGroup}
-              onChange={setSelectedGroup}
-            />
+            <div className="top-overview-container">
+              <GroupSelect
+                  groups={groups}
+                  selectedGroup={selectedGroup}
+                  onChange={setSelectedGroup}
+              />
+              <WeekPicker
+                  startDate={startDate}
+                  onWeekDateChange={handleWeekChange}
+                  labelText={"Select starting week:"}
+              />
+            </div>
+
             <VacationTable
               group={selectedGroupData}
               weeks={weeks}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1166.

Add a date picker similar to the one in report time

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
- Added week picker component
- Added it to VacationOverview page

## Screenshot of the fix
<img width="1591" height="921" alt="image" src="https://github.com/user-attachments/assets/cf8225c0-7cbd-4405-9a61-d2af0746b0fb" />


## Further comments
The issue recommended to use the same component as the report time. In the [date-picker documentation](https://reactdatepicker.com/?) I found a week picker that I found more suitable for this case.

My hope is this is a intuitive component to choose the week from.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
