### PR TITLE
feat: add a 404 page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,18 +4,24 @@ import { Login } from "./pages/Login";
 import { Report } from "./pages/Report";
 import { Help } from "./pages/Help";
 import { AbsencePlanner } from "./pages/AbsencePlanner";
+import { VacationOverview } from "./pages/VacationOverview";
+import { NotFound } from "./pages/NotFound";
 import { AuthProvider } from "./components/AuthProvider";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { getISOWeek, getISOWeekYear } from "date-fns";
 import { ConfirmDialogProvider } from "./components/ConfirmDialogProvider";
 import { EditPeriodDialogProvider } from "./components/EditPeriodDialogProvider";
-import {VacationOverview} from "./pages/VacationOverview";
 
 // Route calls
 // Order of routes is critical.
-// First check for /login, the for the expected /report/year/week.
+// First check is for the root path ("/"), which will redirect to the
+// report page with the current year and week.
+// Next check is for /login, then for the expected /report/year/week.
 // If none of these apply, redirect to /report/year/week using
 // current year and week and replace the history element.
+// If none of the routes match, the NotFound component will be rendered.
+
+
 export const App = () => {
   const currentYear: number = getISOWeekYear(new Date());
   const currentWeek: number = getISOWeek(new Date());
@@ -28,6 +34,15 @@ export const App = () => {
             <EditPeriodDialogProvider>
               <ConfirmDialogProvider>
                 <Routes>
+                  <Route
+                    path="/"
+                    element={
+                      <Navigate
+                        replace
+                        to={`/report/${currentYear}/${currentWeek}`}
+                      />
+                    }
+                  />
                   <Route path="/login" element={<Login />} />
                   <Route
                     path="/report/:year/:week"
@@ -38,7 +53,7 @@ export const App = () => {
                     }
                   />
                   <Route
-                    path="/*"
+                    path="/report"
                     element={
                       <Navigate
                         replace
@@ -62,14 +77,15 @@ export const App = () => {
                       </ProtectedRoute>
                     }
                   />
-                    <Route
-                        path="/vacation"
-                        element={
-                            <ProtectedRoute>
-                                <VacationOverview />
-                            </ProtectedRoute>
-                        }
-                    />
+                  <Route
+                    path="/vacation"
+                    element={
+                      <ProtectedRoute>
+                        <VacationOverview />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route path="*" element={<NotFound />} />
                 </Routes>
               </ConfirmDialogProvider>
             </EditPeriodDialogProvider>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1177,6 +1177,48 @@ Other button classes are defined further down together with other classes for th
   width: 8rem;
 }
 
+/* NOT FOUND */
+
+/* Wrapper with same styles as login-wrapper */
+.not-found-wrapper {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: hsl(70deg 55% 98%);
+}
+
+@media (max-width: 700px) and (orientation: portrait) {
+  .not-found-wrapper {
+    width: 200vw;
+  }
+}
+
+.not-found-section {
+  text-align: center;
+  padding-top: 2rem;
+}
+
+.not-found-heading {
+  font-size: 2rem;
+}
+
+.not-found-message {
+  font-size: 1.125rem;
+  color: hsl(0deg 0% 35%);
+  margin: 0 0 2rem 0;
+}
+
+.not-found-button {
+  background-color: hsl(288deg 46% 22%);
+  color: white;
+  font-size: 1.25rem;
+  border-radius: 0.25rem;
+  border: none;
+  padding: 0.5rem 1rem;
+}
+
 /* ModalDialog styles */
 
 .modal-overlay {

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from "react";
+import { AuthContext } from "../components/AuthProvider";
+import { Link } from "react-router-dom";
+import "../index.css";
+
+export const NotFound = () => {
+  const { user } = useContext(AuthContext);
+
+  return (
+    <main className="not-found-wrapper">
+      <header className="header-wrapper">
+        <img src="mstile-70x70.png" alt="Urdr icon" />
+        <h1 className="header-heading">urdr</h1>
+      </header>
+      <section className="not-found-section">
+        <h2 className="not-found-heading">Page not found</h2>
+        <p className="not-found-message">
+          The page you are looking for does not exist.
+        </p>
+        {user ? (
+          <Link to="/report">
+            <button className="not-found-button">Go to Report</button>
+          </Link>
+        ) : (
+          <Link to="/login">
+            <button className="not-found-button">Go to Login</button>
+          </Link>
+        )}
+      </section>
+    </main>
+  );
+};


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #421.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
<!-- Specify what changes have been made and why -->
- Added a new `NotFound` page that renders when non-existent routes are accessed.
- If the user is logged in, he/she is directed back to the report page.
- If the user is not logged in, he/she is directed to the login page.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
*Logged-in user*
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/992a8c4b-c5b6-4f68-9e18-f4952badaff1" />
*Non-logged-in user*
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/f91c3053-9e70-4c26-8baa-329c80e23601" />

## Testing
<!-- Please delete options that are not relevant -->
- Try entering invalid URLs to see if the application now routes to the new NotFound page.
- Verify the NotFound page's appearance and functionality, including its links/buttons, are displaying correctly.
- Log out of the application (if logged in), try accessing the invalid URLs again to ensure that the button leads to the Login page.
- Log into the application, revisit the invalid URLs, and confirm that the button now leads to the Report page.

## Further comments
<!-- Specify questions or related information -->
The dynamic behavior of the link button was not required in the issue description, but I included it as I think it could make navigation more clear.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
