### PR TITLE
show legend color in front of legend label

### DIFF
--- a/frontend/src/components/VacationOverview/VacationTable.tsx
+++ b/frontend/src/components/VacationOverview/VacationTable.tsx
@@ -40,12 +40,12 @@ export const VacationTable: React.FC<Props> = ({
     <div className="table-wrapper">
       <div className="legend">
         <div className="legend-item">
-          <span className="legend-label">Vacation</span>
           <span className="legend-color vacation"></span>
+          <span className="legend-label">Vacation</span>
         </div>
         <div className="legend-item">
-          <span className="legend-label">Parental Leave</span>
           <span className="legend-color parental"></span>
+          <span className="legend-label">Parental Leave</span>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes issue #1181 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
The legend color is now displayed in front of the legend label for "Vacation" and "Parental leave" on the vacation overview page.

<img width="1738" height="654" alt="image" src="https://github.com/user-attachments/assets/3b03e66e-421b-4131-8d04-4e46936d55bd" />

## Testing
Make sure it looks as described in the issue.
