### PR TITLE
Use english in report date picker

### DIFF
--- a/frontend/src/components/TimeTravel.tsx
+++ b/frontend/src/components/TimeTravel.tsx
@@ -7,7 +7,7 @@ import left from "../icons/caret-left-fill.svg";
 import right from "../icons/caret-right-fill.svg";
 import { useNavigate } from "react-router-dom";
 import { isWeekday } from "../utils";
-import sv from "date-fns/locale/sv";
+import enGB from "date-fns/locale/en-GB";
 
 /*
 TimeTravel
@@ -105,8 +105,8 @@ export const TimeTravel = ({
         endDate={currentWeekArray[4]}
         selectsRange
         showYearDropdown
-        todayButton="Idag"
-        locale={sv}
+        todayButton="Today"
+        locale={enGB}
       />
       <button onClick={nextWeeksClickHandle} className="week-arrow-button">
         <img src={right} alt="switch to next week" className="week-arrow" />


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1180 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
The locale in the date picker on the report page has been changed from "sv" to "enGB"

## Screenshot of the fix
<img width="1310" height="748" alt="image" src="https://github.com/user-attachments/assets/2f0c592e-0228-46a5-b0fb-c2d9b2a065c7" />

## Testing
Make sure that weekdays and the "today" button are displayed in English.