### PR TITLE
Sticky  header and timesum in report time

### DIFF
--- a/frontend/src/components/HeaderRow.tsx
+++ b/frontend/src/components/HeaderRow.tsx
@@ -11,7 +11,7 @@ export const HeaderRow = ({ days }: { days: Date[] }) => {
   const breakpoint = 1267;
 
   return (
-    <div className="row">
+    <div className="header-row row">
       {days.map((day, index) => (
         <p
           key={day.getTime()}
@@ -24,7 +24,7 @@ export const HeaderRow = ({ days }: { days: Date[] }) => {
             : getShortCustomDateString(day)}
         </p>
       ))}
-      <div className="col-1">
+      <div className="col-1 date-cell">
         <h2>Total</h2>
       </div>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,7 @@
   --highlight-today-color: hsl(186deg, 30%, 73%);
   --very_light_gray-background: hsl(0deg 0% 97%);
   --header-height: 80px;
+  --total-row-padding: 60px;
 }
 
 /* This class can be used to hide things visually
@@ -873,6 +874,16 @@ Other button classes are defined further down together with other classes for th
   background-color: var(--very_light_gray-background);
   padding-top: 0.75rem;
   z-index: 1;
+}
+
+.total-row {
+  background-color: var(--very_light_gray-background);
+  bottom: 2rem;
+  margin-bottom: 2rem;
+  position: sticky;
+  padding: 1rem 1.5rem var(--total-row-padding);
+  margin-top: 0.2rem;
+  z-index: 2;
 }
 
 .hide-button {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,8 @@
   --vacation-color: hsl(186deg, 30%, 60%);
   --parental-color: hsl(291deg, 13%, 81%);
   --highlight-today-color: hsl(186deg, 30%, 73%);
+  --very_light_gray-background: hsl(0deg 0% 97%);
+  --header-height: 80px;
 }
 
 /* This class can be used to hide things visually
@@ -167,7 +169,7 @@ Other button classes are defined further down together with other classes for th
   left: 0;
   top: 0;
   width: 100%;
-  height: 80px;
+  height: var(--header-height);
 }
 
 @media (max-width: 700px) and (orientation: portrait) {
@@ -381,6 +383,10 @@ Other button classes are defined further down together with other classes for th
   border: 0.25rem solid var(--highlight-today-color);
 }
 
+.time-sheet-container {
+  background-color: var(--very_light_gray-background);
+}
+
 .recent-container {
   background-color: hsl(0deg 0% 97%);
   padding: 1rem 1.5rem;
@@ -397,7 +403,7 @@ Other button classes are defined further down together with other classes for th
 
 .favorites-container {
   background-color: hsl(0deg 0% 97%);
-  padding: 2.5rem 1.5rem 1rem;
+  padding: 1rem 1.5rem 1rem;
 }
 
 .issue-label {
@@ -859,6 +865,14 @@ Other button classes are defined further down together with other classes for th
 
 .row-focused {
   background-color: hsl(186deg 30% 94%);
+}
+
+.header-row {
+  position: sticky;
+  top: var(--header-height);
+  background-color: var(--very_light_gray-background);
+  padding-top: 0.75rem;
+  z-index: 1;
 }
 
 .hide-button {

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -708,108 +708,108 @@ export const Report = () => {
             }
           }}
         >
-          {favorites && favorites.length > 0 && (
-            <DndContext
-              onDragEnd={handleDragEnd}
-              onDragStart={handleDragStart}
-              collisionDetection={closestCorners}
-              sensors={sensors}
-            >
-              <SortableContext
-                items={favorites.map(
-                  (fav) => `${fav.issue.id}${fav.activity.id}`
-                )}
-                strategy={verticalListSortingStrategy}
-              >
-                <section className="favorites-container">
-                  <HeaderRow days={currentWeekArray} />
-                  {favorites &&
-                    favorites.map((fav) => {
-                      const rowEntries = findRowEntries(fav, currentWeekArray);
-                      return (
+          <section className="time-sheet-container">
+            <HeaderRow days={currentWeekArray} />
+            {favorites && favorites.length > 0 && (
+                <DndContext
+                    onDragEnd={handleDragEnd}
+                    onDragStart={handleDragStart}
+                    collisionDetection={closestCorners}
+                    sensors={sensors}
+                >
+                  <SortableContext
+                      items={favorites.map(
+                          (fav) => `${fav.issue.id}${fav.activity.id}`
+                      )}
+                      strategy={verticalListSortingStrategy}
+                  >
+                    <section className="favorites-container">
+                      {favorites &&
+                          favorites.map((fav) => {
+                            const rowEntries = findRowEntries(fav, currentWeekArray);
+                            return (
+                                <Draggable
+                                    id={`${fav.issue.id}${fav.activity.id}`}
+                                    key={`${fav.issue.id}${fav.activity.id}`}
+                                >
+                                  <Row
+                                      key={`${fav.issue.id}${fav.activity.id}`}
+                                      topic={fav}
+                                      onCellUpdate={handleCellUpdate}
+                                      onToggleFav={handleToggleFav}
+                                      onFavNameUpdate={handleFavNameUpdate}
+                                      onFavNameSave={handleFavNameSave}
+                                      days={currentWeekArray}
+                                      rowHours={findRowHours(fav)}
+                                      rowEntries={rowEntries}
+                                      getRowSum={getRowSum}
+                                      isFav={true}
+                                  />
+                                </Draggable>
+                            );
+                          })}
+                    </section>
+                  </SortableContext>
+                  <DragOverlay>
+                    {draggedFav ? (
                         <Draggable
-                          id={`${fav.issue.id}${fav.activity.id}`}
-                          key={`${fav.issue.id}${fav.activity.id}`}
-                        >
-                          <Row
-                            key={`${fav.issue.id}${fav.activity.id}`}
-                            topic={fav}
+                            id={`${draggedFav.issue.id}${draggedFav.activity.id}`}
+                            children={
+                              <Row
+                                  key={`${draggedFav.issue.id}${draggedFav.activity.id}`}
+                                  topic={draggedFav}
+                                  onCellUpdate={handleCellUpdate}
+                                  onToggleFav={handleToggleFav}
+                                  onFavNameUpdate={handleFavNameUpdate}
+                                  onFavNameSave={handleFavNameSave}
+                                  days={currentWeekArray}
+                                  rowHours={findRowHours(draggedFav)}
+                                  rowEntries={findRowEntries(
+                                      draggedFav,
+                                      currentWeekArray
+                                  )}
+                                  getRowSum={getRowSum}
+                                  isFav={true}
+                              />
+                            }
+                        />
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
+            )}
+            <section className="recent-container">
+              {filteredRecents &&
+                  filteredRecents.map((recentIssue) => {
+                    const rowEntries = findRowEntries(
+                        recentIssue,
+                        currentWeekArray
+                    );
+                    return (
+                        <Row
+                            key={`${recentIssue.issue.id}${recentIssue.activity.id}`}
+                            topic={recentIssue}
                             onCellUpdate={handleCellUpdate}
                             onToggleFav={handleToggleFav}
                             onFavNameUpdate={handleFavNameUpdate}
                             onFavNameSave={handleFavNameSave}
+                            onToggleHide={toggleHide}
                             days={currentWeekArray}
-                            rowHours={findRowHours(fav)}
+                            rowHours={findRowHours(recentIssue)}
                             rowEntries={rowEntries}
                             getRowSum={getRowSum}
-                            isFav={true}
-                          />
-                        </Draggable>
-                      );
-                    })}
-                </section>
-              </SortableContext>
-              <DragOverlay>
-                {draggedFav ? (
-                  <Draggable
-                    id={`${draggedFav.issue.id}${draggedFav.activity.id}`}
-                    children={
-                      <Row
-                        key={`${draggedFav.issue.id}${draggedFav.activity.id}`}
-                        topic={draggedFav}
-                        onCellUpdate={handleCellUpdate}
-                        onToggleFav={handleToggleFav}
-                        onFavNameUpdate={handleFavNameUpdate}
-                        onFavNameSave={handleFavNameSave}
-                        days={currentWeekArray}
-                        rowHours={findRowHours(draggedFav)}
-                        rowEntries={findRowEntries(
-                          draggedFav,
-                          currentWeekArray
-                        )}
-                        getRowSum={getRowSum}
-                        isFav={true}
-                      />
-                    }
-                  />
-                ) : null}
-              </DragOverlay>
-            </DndContext>
-          )}
-          <section className="recent-container">
-            {favorites.length == 0 && (
-              <HeaderRow days={currentWeekArray}></HeaderRow>
-            )}
-            {filteredRecents &&
-              filteredRecents.map((recentIssue) => {
-                const rowEntries = findRowEntries(
-                  recentIssue,
-                  currentWeekArray
-                );
-                return (
-                  <Row
-                    key={`${recentIssue.issue.id}${recentIssue.activity.id}`}
-                    topic={recentIssue}
-                    onCellUpdate={handleCellUpdate}
-                    onToggleFav={handleToggleFav}
-                    onFavNameUpdate={handleFavNameUpdate}
-                    onFavNameSave={handleFavNameSave}
-                    onToggleHide={toggleHide}
-                    days={currentWeekArray}
-                    rowHours={findRowHours(recentIssue)}
-                    rowEntries={rowEntries}
-                    getRowSum={getRowSum}
-                  />
-                );
-              })}
-            <button
-              onClick={() => setShowHidden(!showHidden)}
-              className="basic-button hide-button"
-            >
-              {showHidden ? "Collapse hidden rows" : "Show hidden rows"}
-              <img src={showHidden ? up : down} alt="" />
-            </button>
+                        />
+                    );
+                  })}
+              <button
+                  onClick={() => setShowHidden(!showHidden)}
+                  className="basic-button hide-button"
+              >
+                {showHidden ? "Collapse hidden rows" : "Show hidden rows"}
+                <img src={showHidden ? up : down} alt="" />
+              </button>
+            </section>
           </section>
+
           {showHidden && (
             <section className="recent-container">
               {hidden &&

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -808,92 +808,89 @@ export const Report = () => {
                 <img src={showHidden ? up : down} alt="" />
               </button>
             </section>
-          </section>
-
-          {showHidden && (
-            <section className="recent-container">
-              {hidden &&
-                hidden.map((hiddenIssue) => {
-                  const rowEntries = findRowEntries(
-                    hiddenIssue,
-                    currentWeekArray
-                  );
-                  return (
-                    <Row
-                      key={`${hiddenIssue.issue.id}${hiddenIssue.activity.id}`}
-                      topic={hiddenIssue}
-                      onCellUpdate={handleCellUpdate}
-                      onToggleFav={handleToggleFav}
-                      onFavNameUpdate={handleFavNameUpdate}
-                      onFavNameSave={handleFavNameSave}
-                      onToggleHide={toggleHide}
-                      days={currentWeekArray}
-                      rowHours={findRowHours(hiddenIssue)}
-                      rowEntries={rowEntries}
-                      getRowSum={getRowSum}
-                      isHidden={true}
-                    />
-                  );
-                })}
-            </section>
-          )}
-          <section className="recent-container ">
-            <div className="row">
-              <div className="col-6">
-                <h2>Total</h2>
-              </div>
-              {currentWeekArray &&
-                currentWeekArray.map((date) => {
-                  const dateStr = formatDate(date, dateFormat);
-                  return (
-                    <div key={dateStr} className="col-1 cell-container">
-                      <input
-                        aria-label={`total of hours spent during the day ${dateStr}`}
+            {showHidden && (
+                <section className="recent-container">
+                  {hidden &&
+                      hidden.map((hiddenIssue) => {
+                        const rowEntries = findRowEntries(
+                            hiddenIssue,
+                            currentWeekArray
+                        );
+                        return (
+                            <Row
+                                key={`${hiddenIssue.issue.id}${hiddenIssue.activity.id}`}
+                                topic={hiddenIssue}
+                                onCellUpdate={handleCellUpdate}
+                                onToggleFav={handleToggleFav}
+                                onFavNameUpdate={handleFavNameUpdate}
+                                onFavNameSave={handleFavNameSave}
+                                onToggleHide={toggleHide}
+                                days={currentWeekArray}
+                                rowHours={findRowHours(hiddenIssue)}
+                                rowEntries={rowEntries}
+                                getRowSum={getRowSum}
+                                isHidden={true}
+                            />
+                        );
+                      })}
+                </section>
+            )}
+            <div className="total-row row">
+                <div className="col-6">
+                  <h2>Total</h2>
+                </div>
+                {currentWeekArray &&
+                    currentWeekArray.map((date) => {
+                      const dateStr = formatDate(date, dateFormat);
+                      return (
+                          <div key={dateStr} className="col-1 cell-container">
+                            <input
+                                aria-label={`total of hours spent during the day ${dateStr}`}
+                                type="text"
+                                id={dateStr}
+                                className={isToday(date) ? "cell time-sheet-cell" : "cell"}
+                                value={showTotalHours ? getTotalHours(dateStr) : ""}
+                                readOnly
+                                tabIndex={-1}
+                            />
+                          </div>
+                      );
+                    })}
+                <div className="col-1 cell-container">
+                  <div className="comment-container">
+                    <input
+                        aria-label="total of hours spent during the week"
                         type="text"
-                        id={dateStr}
-                        className={isToday(date) ? "cell time-sheet-cell" : "cell"}
-                        value={showTotalHours ? getTotalHours(dateStr) : ""}
+                        className="cell"
+                        value={showTotalHours ? getTotalHoursWeek() : ""}
                         readOnly
                         tabIndex={-1}
-                      />
-                    </div>
-                  );
-                })}
-              <div className="col-1 cell-container">
-                <div className="comment-container">
-                  <input
-                    aria-label="total of hours spent during the week"
-                    type="text"
-                    className="cell"
-                    value={showTotalHours ? getTotalHoursWeek() : ""}
-                    readOnly
-                    tabIndex={-1}
-                  />
-                  {/* Only show warnings for weeks that have passed. 
-                    It must be at least Saturday. */}
-                  {isPast(addDays(currentWeekArray[4], 1)) && (
-                    <img
-                      src={getTotalHoursWeek() === 40 ? check : warning}
-                      alt={
-                        getTotalHoursWeek() === 40
-                          ? "check: 40 hours logged this week"
-                          : "warning: less or more than 40 hours logged this week"
-                      }
-                      className={
-                        getTotalHoursWeek() === 40
-                          ? "feedback-check"
-                          : "feedback-warning"
-                      }
-                      title={
-                        getTotalHoursWeek() === 40
-                          ? "40 hours logged"
-                          : "less or more than 40 hours logged"
-                      }
                     />
-                  )}
+                    {/* Only show warnings for weeks that have passed.
+                    It must be at least Saturday. */}
+                    {isPast(addDays(currentWeekArray[4], 1)) && (
+                        <img
+                            src={getTotalHoursWeek() === 40 ? check : warning}
+                            alt={
+                              getTotalHoursWeek() === 40
+                                  ? "check: 40 hours logged this week"
+                                  : "warning: less or more than 40 hours logged this week"
+                            }
+                            className={
+                              getTotalHoursWeek() === 40
+                                  ? "feedback-check"
+                                  : "feedback-warning"
+                            }
+                            title={
+                              getTotalHoursWeek() === 40
+                                  ? "40 hours logged"
+                                  : "less or more than 40 hours logged"
+                            }
+                        />
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
           </section>
           <BarChart loading={isLoading}></BarChart>
           <section className="recent-container ">


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes# 855.

In order to see the days of the time sheet and also the total sum the user wants the header and total sum to be sticky.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
 
## List of changes made
Added new CSS classes for header and total sum rows

## Screenshot of the fix
<img width="2379" height="1316" alt="Screenshot from 2025-09-03 13-57-42" src="https://github.com/user-attachments/assets/8750b5ac-2d33-4b9b-9c7d-eddb0089167e" />


## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
