### PR TITLE
Make week picker start with Monday

### DIFF
--- a/frontend/src/components/WeekPicker.tsx
+++ b/frontend/src/components/WeekPicker.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import DatePicker from "react-datepicker";
+import enGB from "date-fns/locale/en-GB";
 
 type Props = {
     onWeekDateChange: (newDate: Date) => void;
@@ -21,6 +22,7 @@ export const WeekPicker : React.FC<Props> = ({
                 selected={startDate}
                 onChange={(date: Date) => onWeekDateChange(date)}
                 dateFormat="I - R"
+                locale={enGB}
                 showWeekNumbers
                 showWeekPicker
             />


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1179  and relates to#1179.

Make week picker start on Monday.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

 
## List of changes made
- added locale

## Screenshot of the fix
<img width="2383" height="1316" alt="Screenshot from 2025-09-03 14-27-03" src="https://github.com/user-attachments/assets/f152647f-79cd-4da8-990b-5be5df14329a" />

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
