### PR TITLE
fix: use English in datepickers on absence reporting page

### DIFF
--- a/frontend/src/pages/AbsencePlanner.tsx
+++ b/frontend/src/pages/AbsencePlanner.tsx
@@ -35,7 +35,7 @@ import {
   startOfWeek,
   isWeekend,
 } from "date-fns";
-import sv from "date-fns/locale/sv";
+import enGB from "date-fns/locale/en-GB";
 import ClimbingBoxLoader from "react-spinners/ClimbingBoxLoader";
 import { HeaderUser } from "../components/HeaderUser";
 import { LoadingOverlay } from "../components/LoadingOverlay";
@@ -595,8 +595,8 @@ export const AbsencePlanner = () => {
       }}
       showWeekNumbers
       showYearDropdown
-      todayButton="Idag"
-      locale={sv}
+      todayButton="Today"
+      locale={enGB}
       selectsStart
       startDate={startDate}
       endDate={endDate}
@@ -618,8 +618,8 @@ export const AbsencePlanner = () => {
       }}
       showWeekNumbers
       showYearDropdown
-      todayButton="Idag"
-      locale={sv}
+      todayButton="Today"
+      locale={enGB}
       selectsEnd
       startDate={startDate}
       endDate={endDate}


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1184.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
<!-- Specify what changes have been made and why -->
The locale in the date picker on the absence report page has been changed from "sv" to "enGB"

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
<img width="2102" height="1376" alt="image" src="https://github.com/user-attachments/assets/f4203043-d5d9-4819-9210-d2a2ebb303bc" />

## Testing
<!-- Please delete options that are not relevant -->
Make sure that months, weekdays and the "today" button are displayed in English.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
