### PR TITLE
Sticky header in vacation table

### DIFF
--- a/frontend/src/components/VacationOverview/VacationTable.tsx
+++ b/frontend/src/components/VacationOverview/VacationTable.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import { Group } from "../../model";
 import { format, addDays } from "date-fns";
 import { ArrowDirection, MonthGroup, WeekInfo } from "./types";
@@ -9,7 +9,9 @@ type Props = {
   group?: Group;
   weeks: WeekInfo[];
   monthGroups: MonthGroup[];
-  vacationData: { [userId: string]: { [date: string]: "vacation" | "parental" }  };
+  vacationData: {
+    [userId: string]: { [date: string]: "vacation" | "parental" };
+  };
   startDate: Date;
   onStartDateChange: (newDate: Date, direction: ArrowDirection) => void;
 };
@@ -37,7 +39,7 @@ export const VacationTable: React.FC<Props> = ({
   };
 
   return (
-    <div className="table-wrapper">
+    <>
       <div className="legend">
         <div className="legend-item">
           <span className="legend-color vacation"></span>
@@ -48,56 +50,56 @@ export const VacationTable: React.FC<Props> = ({
           <span className="legend-label">Parental Leave</span>
         </div>
       </div>
-      <div>
-      </div>
-      <table className="vacation-table table-responsive">
-        <thead>
-          {/* Months */}
-          <tr>
-            <th></th>
-            {monthGroups.map((month) => (
-              <th key={month.name} colSpan={month.colSpan}>
-                {month.name}
-              </th>
-            ))}
-          </tr>
+      <div className="table-wrapper">
+        <div></div>
+        <table className="vacation-table table-responsive">
+          <thead>
+            {/* Months */}
+            <tr>
+              <th></th>
+              {monthGroups.map((month) => (
+                <th key={month.name} colSpan={month.colSpan}>
+                  {month.name}
+                </th>
+              ))}
+            </tr>
 
-          {/* Weeks */}
-          <tr>
-            <th>
-              <button onClick={handleWeekBack}>
-                <img
-                  src={left}
-                  alt="show one week earlier"
-                  className="week-arrow"
-                />
-              </button>
-            </th>
-            {weeks.map((week) => (
-              <th key={week.week} className="week-header">
-                <div> {week.week} </div>
-                <div>{week.dateRange}</div>
+            {/* Weeks */}
+            <tr>
+              <th className="left-header">
+                <button onClick={handleWeekBack}>
+                  <img
+                    src={left}
+                    alt="show one week earlier"
+                    className="week-arrow"
+                  />
+                </button>
               </th>
-            ))}
-            <th className="right-header">
-              <button onClick={handleWeekForward}>
-                <img
-                  src={right}
-                  alt="show one week later"
-                  className="week-arrow"
-                />
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {group &&
-            group.users
-              .sort((a, b) => a.name.localeCompare(b.name))
-              .map((user) => (
-                <tr key={user.id}>
-                  <td className="user-name">{user.name}</td>
-                  {weeks.map((week) => (
+              {weeks.map((week) => (
+                <th key={week.week} className="week-header">
+                  <div> {week.week} </div>
+                  <div>{week.dateRange}</div>
+                </th>
+              ))}
+              <th className="right-header">
+                <button onClick={handleWeekForward}>
+                  <img
+                    src={right}
+                    alt="show one week later"
+                    className="week-arrow"
+                  />
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {group &&
+              group.users
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((user) => (
+                  <tr key={user.id}>
+                    <td className="user-name">{user.name}</td>
+                    {weeks.map((week) => (
                       <td key={week.week}>
                         <div className="week-day-cell">
                           {Array.from({ length: 5 }).map((_, i) => {
@@ -105,23 +107,31 @@ export const VacationTable: React.FC<Props> = ({
                             const dayStr = format(day, "yyyy-MM-dd");
                             const absenceType = vacationData[user.id]?.[dayStr];
                             return (
-                                <div
-                                    key={i}
-                                    className={`day-part ${absenceType === "vacation" ? "vacation" : ""} ${
-                                        absenceType === "parental" ? "parental" : ""
-                                    }`}
-                                    title={`${dayStr}\n${absenceType === "vacation" ? "Vacation" 
-                                        : absenceType === "parental" ? "Parental Leave" : ""}`}
-                                />
+                              <div
+                                key={i}
+                                className={`day-part ${
+                                  absenceType === "vacation" ? "vacation" : ""
+                                } ${
+                                  absenceType === "parental" ? "parental" : ""
+                                }`}
+                                title={`${dayStr}\n${
+                                  absenceType === "vacation"
+                                    ? "Vacation"
+                                    : absenceType === "parental"
+                                    ? "Parental Leave"
+                                    : ""
+                                }`}
+                              />
                             );
                           })}
                         </div>
                       </td>
-                  ))}
-                </tr>
-              ))}
-        </tbody>
-      </table>
-    </div>
+                    ))}
+                  </tr>
+                ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1033,7 +1033,11 @@ Other button classes are defined further down together with other classes for th
 }
 
 .vacation-table th {
-  border-bottom: 0.125rem solid hsl(0deg 0% 35%);
+  box-shadow: 0 1px 0 0 hsl(0deg 0% 35%); /* looks like a border but stays during scroll */
+  position: sticky;
+  top: 0;
+  background-color: hsl(0deg 0% 97%);
+  z-index: 2;
 }
 
 .vacation-table button {
@@ -1046,7 +1050,12 @@ Other button classes are defined further down together with other classes for th
 
 .vacation-table .right-header {
   width: 0;
-  border: none;
+  box-shadow: none;
+  top: 1.7rem;
+}
+
+.vacation-table .left-header {
+  top: 1.7rem;
 }
 
 .vacation-table .user-name {
@@ -1062,6 +1071,7 @@ Other button classes are defined further down together with other classes for th
   text-align: center;
   padding: 0.5rem;
   vertical-align: middle;
+  top: 1.7rem;
 }
 
 .week-day-cell {
@@ -1092,6 +1102,7 @@ Other button classes are defined further down together with other classes for th
   display: flex;
   gap: 2rem;
   margin-bottom: 1rem;
+  margin-top: 0.75rem;
   align-items: center;
 }
 
@@ -1124,6 +1135,8 @@ Other button classes are defined further down together with other classes for th
   overflow-x: auto;
   max-width: 100%;
   margin: 0.75rem auto;
+  overflow-y: auto;
+  max-height: 80vh;
 }
 
 .group-select-wrapper {


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1172 
<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
## List of changes made
<!-- Specify what changes have been made and why -->
- make <th>-cells in vacation table header sticky
- move legend out of table-wrapper to let it stay during scrolling
- replace border with box-shadow to let it stay during scrolling 

## Testing
<!-- Please delete options that are not relevant -->
- go to http://localhost:4567/vacation
- choose a staff group
- start scrolling: if you scroll on top of the table, you should see the table header row stay in place until you see the last row of the table
- try on different screen / window sizes

## Further comments
<!-- Specify questions or related information -->
This was much trickier than I had expected, partly because the html <table> element and `position: sticky` don't work very well together. It's explained here: https://css-tricks.com/position-sticky-and-table-headers/
I'm not entirely happy with the look and feel of this solution but it's the best I could do. If you have suggestions on how to solve this in a different way, please let me know!

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
