### PR TITLE
fix: removing pinned versions for clang and clang ccache issue #1245

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,10 +7,11 @@ WORKDIR /app
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
+# hadolint ignore=DL3018
 RUN apk --no-cache add \
     curl=~8 \
-    clang=~20 \
-    clang-ccache=~20 \
+    clang \
+    clang-ccache \
     musl-dev=~1.2 \
     ccache=~4
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1245 

To solve that the build breaks due to pinned versions of clang and clang-ccache

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
 
## List of changes made
- Removed the pinned versions of clang and clang-ccache
- Added an ignore of the rule DL3018 that wants a package version since Alpine is good with it
The Hadolint check gave these:
    - DL3018 warning: Pin versions in apk add. Instead of `apk add <package> `use `apk add <package>=<version>`
    - DL3059 info: Multiple consecutive RUN instructions. Consider consolidation.

## Testing
Make sure you can build the project.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
