### PR TITLE
fix: show tooltip for zero-width activities in yearly overview

### DIFF
--- a/frontend/src/components/BarChart.tsx
+++ b/frontend/src/components/BarChart.tsx
@@ -116,6 +116,13 @@ export const BarChart = ({ loading }: { loading: boolean }) => {
                 className="bar-chart-section"
               >
                 <Tooltip
+                  position={
+                    index === 0
+                      ? "top-start"
+                      : index === Object.keys(spentTime).length - 1
+                      ? "top-end"
+                      : "top"
+                  }
                   content={
                     <>
                       <p>{spentTime[key].name}</p>

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -3,9 +3,11 @@ import React, { ReactChild, useState } from "react";
 export const Tooltip = ({
   content,
   children,
+  position = "top",
 }: {
   content: string | JSX.Element;
   children: ReactChild;
+  position?: "top" | "top-start" | "top-end";
 }) => {
   const [visible, setVisible] = useState(false);
   return (
@@ -15,7 +17,9 @@ export const Tooltip = ({
       onMouseLeave={() => setVisible(false)}
     >
       {children}
-      {visible && <span className="tooltip-box">{content}</span>}
+      {visible && (
+        <span className={`tooltip-box tooltip-box-${position}`}>{content}</span>
+      )}
     </div>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -446,19 +446,49 @@ Other button classes are defined further down together with other classes for th
   border-radius: 6px;
   padding: 0.5em;
   position: absolute;
-  bottom: 125%;
-  left: 50%;
-  transform: translateX(-50%);
 }
 
 .tooltip-box::after {
   content: "";
   position: absolute;
+  border-width: 5px;
+  border-style: solid;
+}
+
+.tooltip-box-top {
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip-box-top::after {
   top: 100%;
   left: 50%;
   margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
+  border-color: hsl(0deg 0% 0%) transparent transparent transparent;
+}
+
+.tooltip-box-top-start {
+  bottom: 125%;
+  left: 0;
+  white-space: nowrap;
+}
+
+.tooltip-box-top-start::after {
+  top: 100%;
+  left: 8px;
+  border-color: hsl(0deg 0% 0%) transparent transparent transparent;
+}
+
+.tooltip-box-top-end {
+  bottom: 125%;
+  right: 0;
+  white-space: nowrap;
+}
+
+.tooltip-box-top-end::after {
+  top: 100%;
+  right: 8px;
   border-color: hsl(0deg 0% 0%) transparent transparent transparent;
 }
 
@@ -931,7 +961,6 @@ Other button classes are defined further down together with other classes for th
 
 .bar-chart-section {
   height: 100%;
-  padding-left: 0.3rem;
 }
 
 .bar-chart-section p {
@@ -942,6 +971,7 @@ Other button classes are defined further down together with other classes for th
 
 .bar-chart-label {
   width: 100%;
+  padding-left: 0.3rem;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #633.

<!-- Include below a description of the changes proposed in the pull request -->
Activities whose share of the year rounds to 0% are drawn as a 4px sliver in the yearly overview bar so they remain visible. Hovering that sliver produced no tooltip, so the user had no way to tell which activity it was.

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made
- **Sliver had no hover area.** With `box-sizing: border-box`, the `0.3rem` left padding on `.bar-chart-section` consumed the entire 4px width, leaving the tooltip wrapper (which carries the hover handlers) at zero width. Moved the padding to `.bar-chart-label` so the section keeps a non-zero content box and the wrapper spans the full sliver.
- **Tooltip clipped at the chart edges.** A centered tooltip on the first/last segment overflowed the page's left/right edge. Added `top-start` and `top-end` positions to the `Tooltip` component (left-/right-aligned above the bar) and applied them to the first and last segments; middle segments stay centered.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->

<img width="75%" height="auto" alt="image" src="https://github.com/user-attachments/assets/c97f85dd-ca34-47f9-9bdc-158325c84adf" />

---

<img width="75%" height="auto" alt="image" src="https://github.com/user-attachments/assets/334a5972-a5ac-40bb-beec-390c5ec067e9" />


## Testing
<!-- Please delete options that are not relevant -->
  1. Log a small amount of time on an activity so its yearly share rounds to 0% (and ensure it sorts to the first or last segment of the bar).
  2. Open the yearly overview and hover the 4px sliver.
  3. The tooltip with the activity name, hours and % should appear and be fully visible (not clipped off the page edge).

## Further comments
<!-- Specify questions or related information -->
The first/last edge handling is keyed off segment index. A single tiny activity at either end is fully covered; the only uncovered tail case is two consecutive slivers immediately adjacent to an edge (the inner one stays centered and could clip), which was deemed not worth the extra complexity.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
