### PR TITLE
fix: add missing C toolchain to backend dev Dockerfile for cgo build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26-alpine
 
 ENV XDG_CACHE_HOME='/tmp/.cache'
-ENV CC='/usr/lib/ccache/bin/clang'
+ENV CC='/usr/lib/ccache/bin/clang-21'
 
 WORKDIR /app
 
@@ -10,11 +10,13 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018
 RUN apk --no-cache add \
     curl=~8 \
-    clang \
-    clang-ccache \
+    clang21 \
+    clang21-ccache \
+    binutils=~2 \
+    gcc=~15 \
     musl-dev=~1.2 \
     ccache=~4
 
-RUN go install github.com/air-verse/air@v1.65.1
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.65.1
 
 CMD ["air"]


### PR DESCRIPTION
## Related issue(s) and PR(s)
This PR closes #1281.

<!-- Include below a description of the changes proposed in the pull request -->
Fixes the backend development Docker image so `air` can compile the cgo-based SQLite driver (`github.com/mattn/go-sqlite3`) when it rebuilds the app at runtime.

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made
- Add `binutils` and `gcc` — required by the cgo compile/link step for the SQLite driver (verified: air's runtime build fails without them).
- Pin clang and its ccache wrapper to the same major (`clang21` / `clang21-ccache`) and update `CC` to the matching versioned wrapper (`/usr/lib/ccache/bin/clang-21`), removing the compiler/wrapper version-skew risk.
- Fuzzy-pin the new packages (`binutils=~2`, `gcc=~15`) to match the existing `curl`/`musl-dev`/`ccache` pinning style — major-pinned but not nailed to a patch that the Alpine repo may later retire.
- Install `air` with `CGO_ENABLED=0` since it's a pure-Go dev tool and needs no C toolchain.

## Testing
- A rebuild is needed due to new dependencies
- Instructions on how to test:
  1. `docker compose up --build`
  2. Watch the `air` logs for the first `go build`; it should compile the cgo SQLite app without link errors.

## Further comments
<!-- Specify questions or related information -->
Base image package versions are determined by the Alpine release behind `golang:1.26-alpine` (currently Alpine v3.24 → gcc 15.2.0-r5, binutils 2.45.1-r1, clang 21.1.8-r3). To check what the base ships before changing pins:
```
docker run --rm golang:1.26-alpine sh -c 'cat /etc/alpine-release; apk update >/dev/null; apk policy gcc binutils clang21'
```
Index (filter by the v3.24 branch): https://pkgs.alpinelinux.org/packages?branch=v3.24

Pins are intentionally fuzzy/major-only: exact apk pins break when Alpine retires that version from the repo, and these packages are already constrained by the `golang:1.26-alpine` tag.

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
