### PR TITLE
fix: Now the vacation scrolls with viewport

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -832,7 +832,7 @@ Other button classes are defined further down together with other classes for th
   background-color: hsl(0deg 0% 97%);
   padding: 0 3rem 3rem;
   position: relative;
-  height: 650vh;
+  min-height: 100vh;
 }
 
 @media (max-width: 700px) and (orientation: portrait) {
@@ -1071,7 +1071,7 @@ Other button classes are defined further down together with other classes for th
 .vacation-table th {
   box-shadow: 0 1px 0 0 hsl(0deg 0% 35%); /* looks like a border but stays during scroll */
   position: sticky;
-  top: 0;
+  top: var(--header-height);
   background-color: hsl(0deg 0% 97%);
   z-index: 2;
 }
@@ -1087,11 +1087,11 @@ Other button classes are defined further down together with other classes for th
 .vacation-table .right-header {
   width: 0;
   box-shadow: none;
-  top: 1.7rem;
+  top: calc(var(--header-height) + 1.7rem);
 }
 
 .vacation-table .left-header {
-  top: 1.7rem;
+  top: calc(var(--header-height) + 1.7rem);
 }
 
 .vacation-table .user-name {
@@ -1101,13 +1101,13 @@ Other button classes are defined further down together with other classes for th
 }
 
 .vacation-table .week-header {
+  top: calc(var(--header-height) + 1.7rem);
   width: 4rem;
   min-width: 4rem;
   max-width: 4rem;
   text-align: center;
   padding: 0.5rem;
   vertical-align: middle;
-  top: 1.7rem;
 }
 
 .week-day-cell {
@@ -1168,11 +1168,8 @@ Other button classes are defined further down together with other classes for th
 }
 
 .table-wrapper {
-  overflow-x: auto;
   max-width: 100%;
   margin: 0.75rem auto;
-  overflow-y: auto;
-  max-height: 80vh;
 }
 
 .group-select-wrapper {


### PR DESCRIPTION
The previous fix to the sticky header made it so there was sometimes two scrollbars instead of only one global one. This makes it so the table header sticks to the top of the page while scrolling.

Tested in firefox only for now, so that probably has to be looked at.

## Related issue(s) and PR(s)
This PR closes [issue number] and relates to [issue or PR number].

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
## List of changes made
<!-- Specify what changes have been made and why -->
Updates CSS so that the vacation header stays on top of the page without introducing more scrolling containers.

## Screenshot of the fix
<!-- Attach screenshot if relevant -->
<img width="1718" height="626" alt="image" src="https://github.com/user-attachments/assets/754e2959-3d26-4695-84d4-a244fde805a7" />


## Testing
<!-- Please delete options that are not relevant -->
- Instructions on how to test

## Further comments
<!-- Specify questions or related information -->

## Definition of Done checklist
- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [?] My changes generate no new warnings
